### PR TITLE
Updated Level 0 background events

### DIFF
--- a/sysmonconfig-cyberkryption.xml
+++ b/sysmonconfig-cyberkryption.xml
@@ -312,7 +312,7 @@
 			</Rule>
 			<CommandLine name="Attack=T1059.001,Technique=PowerShell,Tactic=Execution,Level=4,Alert=invoke-shellcode,Risk=100" condition="contains">Shellcode</CommandLine>
 			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter: Python-->
-			<Image name="Level=4,Alert=IronPython,Tactic=Privilege Escalation" condition="image">ipy.exe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=IronPython,Tactic=Privilege Escalation" condition="image">ipy.exe</Image>
 			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">python.exe</Image>
 			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter: Javascript-->
 			<CommandLine name="Attack=T1059.007,Technique=PowerShell,Tactic=Execution,Level=3,Alert=JAVA DLL exec" condition="contains">-agentpath:</CommandLine>
@@ -904,7 +904,7 @@
 				<CommandLine condition="contains">0x</CommandLine>
 			</Rule>
 			<!--MITRE ATT&CK TECHNIQUE: Obfuscated Files or Information: Compile After Delivery-->
-			<Rule name="Level=4,Alert=CSC Suspicious Location,Risk=60" groupRelation="and">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=CSC Suspicious Location,Risk=60" groupRelation="and">
 				<Image condition="image">csc.exe</Image>
 				<CommandLine condition="contains any">\AppData\;\Windows\Temp\</CommandLine>
 			</Rule>
@@ -1679,7 +1679,7 @@
 			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=4,Alert=Sysinternals PsPasswd" condition="contains">PsPasswd</Image>
 			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">mstsc.exe</Image>
 			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=Telnet Terminal Emulator" condition="image">telnet.exe</Image>
-			<Image name="Level=3,Alert=TFTP Execution" condition="image">tftp.exe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level==3,Alert=TFTP Execution" condition="image">tftp.exe</Image>
 			<CommandLine name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=IIS powershellcustomhost exec" condition="contains">powershellcustomhost</CommandLine>
 			<!--MITRE ATT&CK TECHNIQUE: Remote Services: Distributed Component Object Model-->
 			<Rule name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement" groupRelation="and">
@@ -1960,7 +1960,7 @@
 			<!--Malicious Keywords Credits: Sean Metcalf (source), Florian Roth (rule)-->
 			<CommandLine name="Attack=T1059,Technique=Command-Line Interface,Tactic=Execution,Level=4,Alert=Malicious Keywords from Exploitation Frameworks" condition="contains any">AdjustTokenPrivileges;IMAGE_NT_OPTIONAL_HDR64_MAGIC;LSA_UNICODE_STRING;Management.Automation.RuntimeException;Metasploit;Microsoft.Win32.UnsafeNativeMethods;Mimikatz;MiniDumpWriteDump;Net.Sockets.SocketFlags;PAGE_EXECUTE_READ;ReadProcessMemory.Invoke;Reflection.Assembly;Runtime.InteropServices;SECURITY_DELEGATION;SE_PRIVILEGE_ENABLED;System.Runtime.InteropServices;System.Security.Cryptography;TOKEN_ADJUST_PRIVILEGES;TOKEN_ALL_ACCESS;TOKEN_ASSIGN_PRIMARY;TOKEN_DUPLICATE;TOKEN_ELEVATION;TOKEN_IMPERSONATE;TOKEN_INFORMATION_CLASS;TOKEN_PRIVILEGES;TOKEN_QUERY;powerkatz</CommandLine>
 			<!--Crypto Currency Miner Detections-->
-			<Rule name="Level=4,Alert=Crypto Currency Miner Detected,Attack=T1496,Technique=Resource Hijacking,Tactic=Impact" groupRelation="or">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=Crypto Currency Miner Detected,Attack=T1496,Technique=Resource Hijacking,Tactic=Impact" groupRelation="or">
 				<CommandLine condition="contains any">ahashpool;blazepool;blockmasters;blockmasterscoins;ccminer;cgminer;coinhive;hashrefinery;minergate;miningpoolhubcoins;nicehash;poolname;poolpassword;poolurl;rainbowminer;sgminer;stratum+tcp;xmrMiner;xmrig;yiimp;zergpool;zergpoolcoins;zpool</CommandLine>
 				<Description condition="contains any">CPU miner;GPU miner;Lime Miner;XMRig CPU miner; miner</Description>
 			</Rule>
@@ -1968,9 +1968,9 @@
 			<Rule name="Attack=T1195,Technique=Supply Chain Compromise,Tactic=Initial Access,Level=4,Alert=Solarwinds/FireEye sunburst hashes,Risk=100" groupRelation="and">
 				<Hashes condition="contains any">b91ce2fa41029f6955bff20079468448;02af7cec58b9a5da1c542b5a32151ba1;2c4a910a1299cdae2a4e55988a2f102e;846e27a652a5e1bfbd0ddd38a16dc865;4f2eb62fa529c0283b28d05ddd311fae;56ceb6d0011d87b6e4d7023d7ef85676</Hashes>
 			</Rule>
-			<Hashes condition="end with" name="Level=0,Desc=plink.exe 64bit imphash matched,Risk=40">87AECF008D87EC86EC8B00A2394B3E6C</Hashes>
-			<Hashes condition="end with" name="Level=0,Desc=plunk.exe 32bit imphash matched,Risk=40">FB3F0D0DE8B80EA8CFAB2A025EC6B833</Hashes>
-			<Hashes condition="end with" name="Level=0,Desc=putty.exe 64bit imphash matched,Risk=40">F4067FBF7FFF6945D0BB485B727B39AA</Hashes>
+			<Hashes condition="end with" name="Attack=None,Technique=None,Tactic=None,Level==0,Desc=plink.exe 64bit imphash matched,Risk=40">87AECF008D87EC86EC8B00A2394B3E6C</Hashes>
+			<Hashes condition="end with" name="Attack=None,Technique=None,Tactic=None,Level==0,Desc=plunk.exe 32bit imphash matched,Risk=40">FB3F0D0DE8B80EA8CFAB2A025EC6B833</Hashes>
+			<Hashes condition="end with" name="Attack=None,Technique=None,Tactic=None,Level==0,Desc=putty.exe 64bit imphash matched,Risk=40">F4067FBF7FFF6945D0BB485B727B39AA</Hashes>
 			<Hashes name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=4,Alert=Generic APT Hash Detection,Risk=100" condition="contains any">4a069c1abe5aca148d5a8fdabc26751e;c96ed56bf7ee85a4398cc43a98b4db86d3da311c619f17c8540ae424ca6546e1;304772c80b157a916c7041f2f15939fb;291ff87948e45914424cec9510c297da;a4b42c2c95d1f2ff12171a01c86cd64f;98908ce6f80ecc48628c8d2bf5b2a50c;849a2b0dc80aeca3d175c139efe5221c;807d86da63f0db1fc746d1f0b05bc357;322cb39bc049aa69136925137906d855;86A4CAC227078B9C95C560C8F0370BF0;36dd195269979e01a29e37c488928497;7d9d29c1c03461608bcab930fef2f568;eac3e3ece94bc84e922ec077efb15edd;b4abe604916c04fe3dd8b9cb3d501d3f;88777aacd5f16599547926a4c9202862;128CECC59C91C0D0574BC1075FE7CB40;17a36ac3e31f3a18936552aff2c80249;0f49621b06f2cdaac8850c6e9581a594;3d129263f6a48647f103a04446fb0c2f;71345b139166482acaa568ac8816c7bc;1b60021baedc3f9201bcdb40e9b87f62;5E022694C0DBD1FBBC263D608E577949;cd4b9d0f2d1c0468750855f0ed352c1ed6d4f512d66e0e44ce308688235295b5;b017b9fc2484ce0a5629ff1fed15bca9f62f942eafbb74da6a40f40337187b04;2010f38ef300be4349e7bc287e720b1ecec678cacbf0ea0556bcf765f6e073ec;6a251ed6a2c6a0a2be11f2a945ec68c814d27e2b6ef445f4b2c7a779620baa11;5b102bf4d997688268bab45336cead7cdf188eb0d6355764e53b4f62e1cdf30c;37cd353621b0f4fc6981b50071c94f01;daf2da52475fd8981b19ec3c321a983c;afcdf79be1557326c854b6e20cb900a7;2f40abbb4f78e77745f0e657a19903fc953cc664;37b4496e650b3994312c838435013560b3ca8571;478dc5a5f934c62a9246f7d1fc275868f568bc07;1a2ab4df156ccd685f795baee7df49f8e701f271d3e5676b507112e30ce03c42;2c1d3d0a9c6f76726994b88589219cb8d9c39dd9924bc8d2d02bf41d955fe326;5c776a33568f4c16fee7140c249c0d2b1e0798a96c7a01bfd2d5684e58c9bb32;5fc4b0076eac7aa7815302b0c3158076e3569086c4c6aa2f71cd258238440d14;08c34c6ac9186b61d9f29a77ef5e618067e0bc9fe85cab1ad25dc6049c376949;758598370c3b84c6fbb452e3d7119f700f970ed566171e879d3cb41102154272;bef59b9a3e00a14956e0cd4a1f3e7524448cbe5d3cc1295d95a15b83a3579c59;c96ed56bf7ee85a4398cc43a98b4db86d3da311c619f17c8540ae424ca6546e1;c96ed56bf7ee85a4398cc43a98b4db86d3da311c619f17c8540ae424ca6546e1;e8542c07b2af63ee7e72ce5d97d91036c5da56e2b091aa2afe737b224305d230;0ac48cfa2ff8351365e99c1d26e082ad;0e9afd3a870906ebf34a0b66d8b07435;1aadf739782afcae6d1c3e4d1f315cbd;2a6f7ec77ab6bd4297e7b15ae06e2e61;3a771efb7ba2cd0df247ab570e1408b2;3d75c72144d873b3c1c4977fbafe9184;3dfebce4703f30eed713d795b90538b5;3ffd2915d285ad748202469d4a04e1f5;4e39620afca6f60bb30e031ddc5a4330;6cfd131fef548fcd60fbcdb59317df8e;7bcd736a2394fc49f3e27b3987cce640;7bfba2c69bed6b160261bdbf2b826401;7bfbd72441e1f2ed48fbc0f33be00f24;7c733607a0932b1b9a9e27cd6ab55fe0;7d5265e814843b24fcb3787768129040;08e82dc7bae524884b7dc2134942aadb;8da15a97eaf69ff7ee184fc446f19cf1;9ad6fa6fdedb2df8055b3d30bd6f64f1;9c115e9a81d25f9d88e7aaa4313d9a8f;16ab79fb2fd92db0b1f38bedb2f02ed8;21feb6aa15e02bb0cddbd544605aabad;21feb6aa15e02bb0cddbd544605aabad;22d142f11cf2a30ea4953e1fffb0fa7e;36db24006e2b492cafb75f2663f241b2;51a7068640af42c3a7c1b94f1c11ab9d;69a19abf5ba56ee07cdd3425b07cf8bf;72dc98449b45a7f1ccdef27d51e31e91;77a745b07d9c453650dd7f683b02b3ed;80c37e062aa4c94697f287352acf2e9d;92f8e3f0f1f7cc49fad797a62a169acd;235d427f94630575a4ea4bff180ecf5d;320b2f1d9551b5d1df4fb19bd9ab253a;490a140093b5870a47edc29f33542fd2;520ee02668a1c7b7c262708e12b1ba6b;649ef1dd4a5411d3afcf108d57ff87af;684eca6b62d69ce899a3ec3bb04d0a5b;815f1f8a7bc1e6f94cb5c416e381a110;0969b2b399a8d4cd2d751824d0d842b4;2317d65da4639f4246de200650a70753;04078ef95a70a04e95bda06cc7bec3fa;8035a8a143765551ca7db4bc5efb5dfd;8403a28e0bffa9cc085e7b662d0d5412;9003cfaac523e94d5479dc6a10575e60;9793afcea43110610757bd3b800de517;27612cb03c89158225ca201721ea1aad;44619a88a6cff63523163c6a4cf375dd;061089d8cb0ca58e660ce2e433a689b3;81229c1e272218eeda14892fa8425883;84730a6e426fbd3cf6b821c59674c8a0;533340c54bd25256873b3dca34d7f74e;57314359df11ffdf476f809671ec0275;99828721ac1a0e32e4582c3f615d6e57;412956675fbc3f8c51f438c1abc100eb;5985087678414143d33ffc6e8863b887;a43d3b31575846fa4c3992b4143a06da;a571660c9cf1696a2f4689b2007a12c7;b4e67706103c3b8ee148394ebee3f268;b9c208ea8115232bfd9ec2c62f32d6b8;b9cf4301b7b186a75e82a04e87b30fe4;b72737b464e50aa3664321e8e001ff32;bfe3f6a79cad5b9c642bb56f8037c43b;c0e72eb4c9f897410c795c1b360090ef;c1e7850da5604e081b9647b58248d7e8;c3e255888211d74cc6e3fb66b69bbffb;cacaa3bf3b2801956318251db5e90f3c;cdb303f61a47720c7a8c5086e6b2a743;ce8ce92fb6565181572dce00d69c24f8;d8f1356bebda9e77f480a6a60eab36bb;d9e9f22988d43d73d79db6ee178d70a4;d5377dc1821c935302c065ad8432c0d2;df91b86189adb0a11c47ce2405878fa1;e17bd40f5b5005f4a0c61f9e79a9d8c2;f559c87b4a14a4be1bd84df6553aaf56;fc53f2cd780cd3a01a4299b8445f8511;ffc7305cb24c1955f9625e525d58aeee</Hashes>
 			<Hashes name="Attack=T1353,Technique=Post Compromise Tool Development,Tactic=Build Capabilities,Level=4,Alert=Windows Credential Editor Detection,Risk=70" condition="contains any">e96a73c7bf33a464c510ede582318bf2;a53a02b997935fd8eedcb5f7abab9b9f</Hashes>
 			<Hashes name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=Ransomware Hash Detection,Risk=100" condition="contains any">d326e629a90e78825645963b35e53a6a;c579341f86f7e962719c7113943bb6e4;dc5733c013378fa418d13773f5bfe6f1;b8fcd4a3902064907fb19e0da3ca7aed72a7e6d1f94d971d1ee7a4d3af6a800d;965884f19026913b2c57b8cd4a86455a61383de01dabb69c557f45bb848f6c26;4a069c1abe5aca148d5a8fdabc26751e;dc7e564809d6c2a2f3457c3c9b91f22b;FE2CA1BE3BDA2A757036A89E54CC02DB;5470f0644589685000154cb7d3f60280acb16e39ca961cce2c016078b303bc1b</Hashes>
@@ -2052,22 +2052,22 @@
 			</Rule>
 			<Image name="Attack=T1222,Technique=File Permissions Modification,Tactic=Defense Evasion,Level=0,Desc=Permission Modifications with icacls or cacls" condition="contains">cacls</Image>
 			<Image name="Attack=T1222,Technique=File Permissions Modification,Tactic=Defense Evasion,Level=0,Desc=Ownership Permission Modifications with takeown" condition="contains">takeown</Image>
-			<CommandLine condition="contains" name="Level=0,Desc=Suspicious Cmdline: MsAccess MACRO Exec">/x Macro</CommandLine>
-			<Rule  name="Level=3,Desc=Suspicious pipe via commandline" groupRelation="and">
+			<CommandLine condition="contains" name="Attack=None,Technique=None,Tactic=None,Level==0,Desc=Suspicious Cmdline: MsAccess MACRO Exec">/x Macro</CommandLine>
+			<Rule  name="Attack=None,Technique=None,Tactic=None,Level=3,Desc=Suspicious pipe via commandline" groupRelation="and">
 				<CommandLine condition="contains">\pipe\</CommandLine>
 				<CommandLine condition="excludes">&gt;</CommandLine> <!--Excludes piping to pipe for cobalt strike detection-->
 			</Rule>
-			<CommandLine condition="contains" name="Level=0,Desc=Suspicious Cmdline: RDP Port">/noprofile</CommandLine>
-			<CommandLine condition="contains" name="Level=0,Desc=Suspicious Cmdline: Schtasks">/sc ONEVENT</CommandLine>
-			<CommandLine name="Level=3,Alert=Execution run from \\VBOXSVR share" condition="contains">\\VBOXSVR</CommandLine>
-			<CommandLine name="Level=3,Alert=interactive command to slow output" condition="contains">| more</CommandLine>
-			<CommandLine name="Level=3,Alert=interactive command to slow output" condition="contains">|more</CommandLine>
+			<CommandLine condition="contains" name="Attack=None,Technique=None,Tactic=None,Level==0,Desc=Suspicious Cmdline: RDP Port">/noprofile</CommandLine>
+			<CommandLine condition="contains" name="Attack=None,Technique=None,Tactic=None,Level==0,Desc=Suspicious Cmdline: Schtasks">/sc ONEVENT</CommandLine>
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level==3,Alert=Execution run from \\VBOXSVR share" condition="contains">\\VBOXSVR</CommandLine>
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level==3,Alert=interactive command to slow output" condition="contains">| more</CommandLine>
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level==3,Alert=interactive command to slow output" condition="contains">|more</CommandLine>
 			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\\tsclient</CommandLine>
 			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">%PROCESSOR_ARCHITECTURE%</CommandLine>
 			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">sysnative</CommandLine>
 			<Description name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">AutoIt</Description>
 			<Description name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Microsoft Filter Loader</Description> 
-			<Image name="Level=3,Alert=interactive command to slow output" condition="is">more.com</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level==3,Alert=interactive command to slow output" condition="is">more.com</Image>
 			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">:\Windows\Microsoft.NET\</Image>
 			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">acrord32.exe</Image>
 			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">gpupdate.exe</Image>
@@ -2230,7 +2230,7 @@
 			<Rule name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network Connection from wwwroot folder: Possible webshell,Risk=100" groupRelation="and">
 				<Image condition="contains">\wwwroot\</Image>
 			</Rule>
-			<Image name="Level=4,Alert=Network connection in addins" condition="contains">\Windows\addins\</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=Network connection in addins" condition="contains">\Windows\addins\</Image>
 			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network Connection from Windows\repair Folder,Risk=70" condition="begin with">C:\Windows\repair\</Image>
 			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network Connection from htdocs folder,Risk=70" condition="contains">\htdocs\</Image>
 			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network Connection from systemprofile Folder,Risk=30" condition="begin with">C:\Windows\system32\config\systemprofile\</Image>
@@ -2543,7 +2543,7 @@
 			<!--MITRE ATT&CK TECHNIQUE: Inhibit System Recovery-->
 			<!--MITRE ATT&CK TECHNIQUE: Network Denial of Service-->
 			<!--MITRE ATT&CK TECHNIQUE: Resource Hijacking-->
-			<DestinationHostname name="Level=4,Alert=Crypto Currency Miner Detected,Attack=T1496,Technique=Resource Hijacking,Tactic=Impact,Risk=100" condition="contains any">0x1f4b0.com;1q2w3.life;1q2w3.website;31.187.64.216;185.193.38.148;aalbbh84.info;adfreetv.ch;adless.io;adplusplus.fr;adrenali.gq;ajcryptominer.com;ajplugins.com;allfontshere.press;altavista.ovh;amhixwqagiz.ru;analytics.blue;appelamule.com;arizona-miner.tk;aster18cdn.nl;aster18prx.nl;avero.xyz;averoconnector.com;bauersagtnein.myeffect.net;bhzejltg.info;blazepool;blockmasters;blockmasterscoins;bmnr.pw;bmst.pw;bohemianpool;carry.myeffect.net;cashbeet.com;cdn-code.host;cfceu.duckdns.org;cfcnet.gdn;cfcnet.top;cfcs1.duckdns.org;chainblock.science;cieh.mx;coin-hive.com;coin-service.com;coin-services.info;coiner.site;coinpirate.cf;coinrail.io;coinwebmining.com;cpu2cash.link;cryptaloot.pro;cryptmonero;crypto-loot.com;crypto-pool;crypto-webminer.com;cryptoloot.pro;d-ns.ga;dataservices.download;directprimal.com;dwarfpool;encoding.ovh;estream.to;eth-pocket.com;eth-pocket.de;eth-pocket.eu;ethereum-pocket.de;ethereum-pocket.eu;ethtrader.de;eu.sushipool.com;f1tbit.com;flnqmin.org;freecontent.bid;freecontent.date;freecontent.loan;freecontent.racing;freecontent.stream;freecontent.win;gnrdomimplementation.com;graftpool.ovh;greenindex.dynamic-dns.net;gustaver.ddns.net;hashrefinery;hashvault.pro;herphemiste.com;hide.ovh;hk.rs;hlpidkr.ru;hodlers.party;hodling.faith;hostingcloud.win;hrfziiddxa.ru;ihdvilappuxpgiv.ru;imhvlhaelvvbrq.ru;insdrbot.com;irrrymucwxjl.ru;istlandoll.com;ivuovhsn.ru;iwanttoearn.money;ixvenhgwukn.ru;jqassets.download;jqr-cdn.download;jqrcdn.download;jquerrycdn.download;jqwww.download;jqxrrygqnagn.ru;jscoinminer.com;jwduahujge.ru;ksimdw.ru;l33tsite.info;laferia.cr;ledhenone.com;ltstyov.ru;mepirtedic.com;mine.bz;minercircle.com;minercry.pt;minergate;minero.cc;miners.pro;minescripts.info;mininghub.club;miningpoolhubcoins;minr.pw;mixpools.org;mmc.center;mollnia.com;monerise.com;monero.lindon-pool.win;monero;moriaxmr.com;munero.me;mxcdn1.now.sh;mxcdn2.now.sh;myadstats.com;mypool.online;nablabee.com;nanopool.org;nathetsof.com;nicehash;nimiqpool.com;nimpool.io;node.philpool.com;npcdn1.now.sh;nunu-001.now.sh;ogondkskyahxa.ru;ogrid.org;oinkinns.tk;olecintri.com;omine.org;onvid.club;open-hive-server-1.pp.ua;oxwwoeukjispema.ru;pcejuyhjucmkiny.ru;pool.nimiq.watch;pool.nimiqchain.info;pool.porkypool.com;pool.xmr;poolto.be;prohash.net;prohash;proj2018.xyz;pzoifaum.info;ratchetmining.com;realnetwrk.com;reauthenticator.com;rove.cl;ruvuryua.ru;s7ven.com;scaleway.ovh;sentemanactri.com;sickrage.ca/ch;sighash.info;slushpool;soodatmish.com;sparechange.io;statdynamic.com;stati.bid;staticsfs.host;streamplay.to;supportxmr;suprnova.cc;svivqrhrh.ru;sxcdn02.now.sh;sxcdn3.now.sh;sxcdn4.now.sh;sxcdn6.now.sh;synconnector.com;teracycle.net;tercabilis.info;thelifeisbinary.ddns.net;thersprens.com;torrent.pw;ulnawoyyzbljc.ru;unrummaged.com;uoldid.ru;usxmrpool;viaxmr.com;vpzccwpyilvoyg.ru;vzzexalcirfgrf.ru;wbmwss.beetv.net;webmine.cz;webmine.pro;webminepool.tk;webminerpool.com;webwidgetz.duckdns.org;wmemsnhgldd.ru;wmtech.website;wmwmwwfmkvucbln.ru;wrxgandsfcz.ru;xmrm.pw;xmrminingproxy.com;xmrpool;yiimp;yuyyio.com;zavzlen.ru;zergpool;zergpoolcoins;ziykrgc.ru;zlx.com.br;zpool</DestinationHostname>
+			<DestinationHostname name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=Crypto Currency Miner Detected,Attack=T1496,Technique=Resource Hijacking,Tactic=Impact,Risk=100" condition="contains any">0x1f4b0.com;1q2w3.life;1q2w3.website;31.187.64.216;185.193.38.148;aalbbh84.info;adfreetv.ch;adless.io;adplusplus.fr;adrenali.gq;ajcryptominer.com;ajplugins.com;allfontshere.press;altavista.ovh;amhixwqagiz.ru;analytics.blue;appelamule.com;arizona-miner.tk;aster18cdn.nl;aster18prx.nl;avero.xyz;averoconnector.com;bauersagtnein.myeffect.net;bhzejltg.info;blazepool;blockmasters;blockmasterscoins;bmnr.pw;bmst.pw;bohemianpool;carry.myeffect.net;cashbeet.com;cdn-code.host;cfceu.duckdns.org;cfcnet.gdn;cfcnet.top;cfcs1.duckdns.org;chainblock.science;cieh.mx;coin-hive.com;coin-service.com;coin-services.info;coiner.site;coinpirate.cf;coinrail.io;coinwebmining.com;cpu2cash.link;cryptaloot.pro;cryptmonero;crypto-loot.com;crypto-pool;crypto-webminer.com;cryptoloot.pro;d-ns.ga;dataservices.download;directprimal.com;dwarfpool;encoding.ovh;estream.to;eth-pocket.com;eth-pocket.de;eth-pocket.eu;ethereum-pocket.de;ethereum-pocket.eu;ethtrader.de;eu.sushipool.com;f1tbit.com;flnqmin.org;freecontent.bid;freecontent.date;freecontent.loan;freecontent.racing;freecontent.stream;freecontent.win;gnrdomimplementation.com;graftpool.ovh;greenindex.dynamic-dns.net;gustaver.ddns.net;hashrefinery;hashvault.pro;herphemiste.com;hide.ovh;hk.rs;hlpidkr.ru;hodlers.party;hodling.faith;hostingcloud.win;hrfziiddxa.ru;ihdvilappuxpgiv.ru;imhvlhaelvvbrq.ru;insdrbot.com;irrrymucwxjl.ru;istlandoll.com;ivuovhsn.ru;iwanttoearn.money;ixvenhgwukn.ru;jqassets.download;jqr-cdn.download;jqrcdn.download;jquerrycdn.download;jqwww.download;jqxrrygqnagn.ru;jscoinminer.com;jwduahujge.ru;ksimdw.ru;l33tsite.info;laferia.cr;ledhenone.com;ltstyov.ru;mepirtedic.com;mine.bz;minercircle.com;minercry.pt;minergate;minero.cc;miners.pro;minescripts.info;mininghub.club;miningpoolhubcoins;minr.pw;mixpools.org;mmc.center;mollnia.com;monerise.com;monero.lindon-pool.win;monero;moriaxmr.com;munero.me;mxcdn1.now.sh;mxcdn2.now.sh;myadstats.com;mypool.online;nablabee.com;nanopool.org;nathetsof.com;nicehash;nimiqpool.com;nimpool.io;node.philpool.com;npcdn1.now.sh;nunu-001.now.sh;ogondkskyahxa.ru;ogrid.org;oinkinns.tk;olecintri.com;omine.org;onvid.club;open-hive-server-1.pp.ua;oxwwoeukjispema.ru;pcejuyhjucmkiny.ru;pool.nimiq.watch;pool.nimiqchain.info;pool.porkypool.com;pool.xmr;poolto.be;prohash.net;prohash;proj2018.xyz;pzoifaum.info;ratchetmining.com;realnetwrk.com;reauthenticator.com;rove.cl;ruvuryua.ru;s7ven.com;scaleway.ovh;sentemanactri.com;sickrage.ca/ch;sighash.info;slushpool;soodatmish.com;sparechange.io;statdynamic.com;stati.bid;staticsfs.host;streamplay.to;supportxmr;suprnova.cc;svivqrhrh.ru;sxcdn02.now.sh;sxcdn3.now.sh;sxcdn4.now.sh;sxcdn6.now.sh;synconnector.com;teracycle.net;tercabilis.info;thelifeisbinary.ddns.net;thersprens.com;torrent.pw;ulnawoyyzbljc.ru;unrummaged.com;uoldid.ru;usxmrpool;viaxmr.com;vpzccwpyilvoyg.ru;vzzexalcirfgrf.ru;wbmwss.beetv.net;webmine.cz;webmine.pro;webminepool.tk;webminerpool.com;webwidgetz.duckdns.org;wmemsnhgldd.ru;wmtech.website;wmwmwwfmkvucbln.ru;wrxgandsfcz.ru;xmrm.pw;xmrminingproxy.com;xmrpool;yiimp;yuyyio.com;zavzlen.ru;zergpool;zergpoolcoins;ziykrgc.ru;zlx.com.br;zpool</DestinationHostname>
 			<!--MITRE ATT&CK TECHNIQUE: Service Stop-->
 			<!--MITRE ATT&CK TECHNIQUE: System Shutdown/Reboot-->
 			<!--UEBA Rules-->
@@ -2580,7 +2580,7 @@
 				<SourceIp condition="excludes any">127.0.0.1;0:0:0:0:0:0:0:1;fe80:0</SourceIp>
 				<Initiated>false</Initiated>
 			</Rule>
-			<Rule name="Level=4,Alert=Notepad connecting to the internet" groupRelation="and">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=Notepad connecting to the internet" groupRelation="and">
 				<Image condition="image">notepad.exe</Image>
 				<DestinationIp condition="excludes">127.0.0.1</DestinationIp>
 			</Rule>
@@ -3092,7 +3092,7 @@
 			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
 				<SignatureStatus condition="is">Expired</SignatureStatus>
 			</Rule>
-			<Rule name="Level=4,Alert=HTA Exec with IE JS Engine AMSI Bypass" groupRelation="and">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=HTA Exec with IE JS Engine AMSI Bypass" groupRelation="and">
 				<ImageLoaded condition="end with">jscript9.dll</ImageLoaded>
 				<Image condition="image">mshta.exe</Image>
 			</Rule>
@@ -3426,8 +3426,8 @@
 				<TargetImage condition="excludes">C:\WINDOWS\system32\sihost.exe</TargetImage>
 				<TargetImage condition="excludes">C:\Program Files\WindowsApps\Microsoft.MicrosoftOfficeHub</TargetImage>
 			</Rule>
-			<CallTrace name="Level=4,Alert=CobaltStrike BOF using OpenProcess/NtOpenProcess" condition="begin with">UNKNOWN</CallTrace>
-			<Rule name="Level=4,Alert=Typical ProcessAccess Pattern of CobaltStrike BOF" groupRelation="and">
+			<CallTrace name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=CobaltStrike BOF using OpenProcess/NtOpenProcess" condition="begin with">UNKNOWN</CallTrace>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=Typical ProcessAccess Pattern of CobaltStrike BOF" groupRelation="and">
 				<CallTrace condition="contains">|UNKNOWN(</CallTrace>
 				<CallTrace condition="begin with">C:\WINDOWS\SYSTEM32\ntdll.dll+</CallTrace>
 				<CallTrace condition="contains">|C:\WINDOWS\System32\KERNELBASE.dll+</CallTrace>
@@ -3435,11 +3435,11 @@
 				<GrantedAccess condition="contains any">0x1028;0x1fffff</GrantedAccess>
 				<SourceImage condition="excludes any">C:\Program Files\SmartGit\bin\;C:\Program Files (x86)\ASUS\Update\;C:\Program Files (x86)\Razer\Synapse3\Service\Razer Synapse Service.exe;C:\Program Files (x86)\Citrix\ICA Client\Receiver\UpdaterService.exe;C:\WINDOWS\SysWOW64\config\systemprofile\Citrix\UpdaterBinaries\;C:\Program Files\Mozilla Firefox\firefox.exe;C:\Program Files\SmartGit\git\</SourceImage>
 			</Rule>
-			<Rule name="Level=3,Alert=Potential MalDoc Behavior" groupRelation="and">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level==3,Alert=Potential MalDoc Behavior" groupRelation="and">
 				<SourceImage condition="contains any">winword.exe;excel.exe;powerpnt.exe</SourceImage>
 				<CallTrace condition="contains all">:\Windows\Microsoft.NET\Framework64\v2.;UNKNOWN</CallTrace>
 			</Rule>
-			<Rule name="Level=4,Alert=Potential Metasploit Process Migration" groupRelation="and">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=Potential Metasploit Process Migration" groupRelation="and">
 				<CallTrace condition="contains">UNKNOWN</CallTrace>
 				<GrantedAccess condition="contains">0x147a</GrantedAccess>
 			</Rule>
@@ -3773,8 +3773,8 @@
 				<TargetFilename condition="contains">\AppData\Temp\</TargetFilename>
 				<Image condition="excludes">C:\WINDOWS\system32\dxgiadaptercache.exe</Image>
 			</Rule>
-			<TargetFilename condition="contains" name="Level=0,Desc=Recycle bin files created">$Recycle.Bin</TargetFilename>
-			<Image condition="contains" name="Level=0,Desc=Files Created from">$Recycle.Bin</Image>
+			<TargetFilename condition="contains" name="Attack=None,Technique=None,Tactic=None,Level==0,Desc=Recycle bin files created">$Recycle.Bin</TargetFilename>
+			<Image condition="contains" name="Attack=None,Technique=None,Tactic=None,Level==0,Desc=Files Created from">$Recycle.Bin</Image>
 			<Rule name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Risk=20,Level=0,Desc=Files Created within System Profile" groupRelation="and">
 				<TargetFilename condition="begin with">C:\Windows\</TargetFilename>
 				<TargetFilename condition="contains">\config\systemprofile\</TargetFilename>
@@ -4102,8 +4102,8 @@
 			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\UsageLogs\wscript.exe.log</TargetFilename>
 			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\regsvr32.exe.log</TargetFilename>
 			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Winrm Host Process" condition="end with">\UsageLogs\wsmprovhost.exe.log</TargetFilename>
-			<TargetFilename name="Level=0,Desc=Link">.lnk</TargetFilename>
-			<TargetFilename name="Level=0,Desc=URL">.url</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level==0,Desc=Link">.lnk</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level==0,Desc=URL">.url</TargetFilename>
 			<!--Drivers dropped-->
 			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.sys</TargetFilename>
 			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.inf</TargetFilename>
@@ -4563,7 +4563,7 @@
 				<EventType condition="is">CreateKey</EventType>
 			</Rule>
 			<!--MITRE ATT&CK TECHNIQUE: Create or Modify System Process-->
-			<Rule name="Level=3,Alert=Sysmon Manifest change detected,Risk=30" groupRelation="and">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level==3,Alert=Sysmon Manifest change detected,Risk=30" groupRelation="and">
 				<TargetObject condition="begin with">HKLM\Microsoft\Windows\CurrentVersion\WINEVT\Publishers\{5770385f-c22a-43e0-bf4c-06f5698ffbd9}</TargetObject>
 				<Image condition="excludes">C:\WINDOWS\sysmon64.exe</Image>
 				<Image condition="excludes">C:\WINDOWS\sysmon.exe</Image>
@@ -5470,7 +5470,7 @@
 				<TargetFilename condition="contains any">Content.IE5;INetCache</TargetFilename>
 				<TargetFilename condition="contains any">.exe;.zip;.ps1;.bat;.rar;.vbs;.hta</TargetFilename>
 			</Rule>
-			<Rule name="Level=4,Alert=HTML_Smuggling,Risk=50" groupRelation="and">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=HTML_Smuggling,Risk=50" groupRelation="and">
 				<TargetFilename condition="end with">:Zone.Identifier</TargetFilename>
 				<Contents condition="contains any">blob:;about:internet</Contents>
 			</Rule>
@@ -5684,7 +5684,7 @@
 				<QueryName condition="contains any">.slack.com;discord.;telegram.;rocketchat.;mattermost.;flock.com</QueryName>
 			</Rule>
 			<!--Crypto Currency Mining pools-->
-			<Rule name="Level=4,Alert=Crypto Currency Miner Detected,Attack=T1496,Technique=Resource Hijacking,Tactic=Impact,Risk=10"  groupRelation="or">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level==4,Alert=Crypto Currency Miner Detected,Attack=T1496,Technique=Resource Hijacking,Tactic=Impact,Risk=10"  groupRelation="or">
 				<QueryName condition="contains any">0x1f4b0.com;1q2w3.life;1q2w3.website;31.187.64.216;185.193.38.148;aalbbh84.info;adfreetv.ch;adless.io;adplusplus.fr;adrenali.gq;ajcryptominer.com;ajplugins.com;allfontshere.press;altavista.ovh;amhixwqagiz.ru;appelamule.com;arizona-miner.tk;aster18cdn.nl;aster18prx.nl;avero.xyz;averoconnector.com;bauersagtnein.myeffect.net;bhzejltg.info;blazepool;blockmasters;blockmasterscoins;bmnr.pw;bmst.pw;bohemianpool;carry.myeffect.net;cashbeet.com;cdn-code.host;cfceu.duckdns.org;cfcnet.gdn;cfcnet.top;cfcs1.duckdns.org;chainblock.science;cieh.mx;coin-hive.com;coin-service.com;coin-services.info;coiner.site;coinpirate.cf;coinrail.io;coinwebmining.com;cpu2cash.link;cryptaloot.pro;cryptmonero;crypto-loot.com;crypto-pool;crypto-webminer.com;cryptoloot.pro;d-ns.ga;dataservices.download;directprimal.com;dwarfpool;encoding.ovh;eth-pocket.com;eth-pocket.de;eth-pocket.eu;ethereum-pocket.de;ethereum-pocket.eu;ethtrader.de;eu.nimpool.io;eu.sushipool.com;f1tbit.com;flnqmin.org;freecontent.bid;freecontent.date;freecontent.loan;freecontent.racing;freecontent.stream;freecontent.win;gnrdomimplementation.com;graftpool.ovh;greenindex.dynamic-dns.net;gustaver.ddns.net;hashrefinery;hashvault.pro;herphemiste.com;hide.ovh;hk.rs;hlpidkr.ru;hodlers.party;hodling.faith;hostingcloud.win;hrfziiddxa.ru;ihdvilappuxpgiv.ru;imhvlhaelvvbrq.ru;insdrbot.com;irrrymucwxjl.ru;istlandoll.com;ivuovhsn.ru;iwanttoearn.money;ixvenhgwukn.ru;jqassets.download;jqr-cdn.download;jqrcdn.download;jquerrycdn.download;jqwww.download;jqxrrygqnagn.ru;jscoinminer.com;jwduahujge.ru;ksimdw.ru;l33tsite.info;laferia.cr;ledhenone.com;ltstyov.ru;mepirtedic.com;mine.bz;minercircle.com;minercry.pt;minergate;minero.cc;miners.pro;minescripts.info;mininghub.club;miningpoolhubcoins;minr.pw;mixpools.org;mmc.center;mollnia.com;monerise.com;monero.lindon-pool.win;monero;moriaxmr.com;munero.me;mxcdn1.now.sh;mxcdn2.now.sh;myadstats.com;mypool.online;nablabee.com;nanopool.org;nathetsof.com;nicehash;nimiqpool.com;node.philpool.com;npcdn1.now.sh;nunu-001.now.sh;ogondkskyahxa.ru;ogrid.org;oinkinns.tk;olecintri.com;omine.org;onvid.club;open-hive-server-1.pp.ua;oxwwoeukjispema.ru;pcejuyhjucmkiny.ru;pool.nimiq.watch;pool.nimiqchain.info;pool.porkypool.com;pool.xmr;poolto.be;prohash.net;prohash;proj2018.xyz;pzoifaum.info;ratchetmining.com;realnetwrk.com;reauthenticator.com;rove.cl;ruvuryua.ru;s7ven.com;scaleway.ovh;sentemanactri.com;sickrage.ca/ch;sighash.info;slushpool;soodatmish.com;sparechange.io;statdynamic.com;stati.bid;staticsfs.host;streamplay.to;suprnova.cc;svivqrhrh.ru;sxcdn02.now.sh;sxcdn3.now.sh;sxcdn4.now.sh;sxcdn6.now.sh;synconnector.com;teracycle.net;tercabilis.info;thelifeisbinary.ddns.net;thersprens.com;torrent.pw;ulnawoyyzbljc.ru;unrummaged.com;uoldid.ru;usxmrpool;viaxmr.com;vpzccwpyilvoyg.ru;vzzexalcirfgrf.ru;wbmwss.beetv.net;webmine.cz;webmine.pro;webminepool.tk;webminerpool.com;webwidgetz.duckdns.org;wmemsnhgldd.ru;wmtech.website;wmwmwwfmkvucbln.ru;wrxgandsfcz.ru;xmrm.pw;xmrminingproxy.com;xmrpool;yiimp;yuyyio.com;zavzlen.ru;zergpool;zergpoolcoins;ziykrgc.ru;zlx.com.br;zpool;analytics.blue;estream.to</QueryName>
 			</Rule>
 			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">graph.microsoft.com</QueryName>
@@ -5741,7 +5741,7 @@
 			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">_kerberos._udp.dc._msdcs.</QueryName>
 			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">_ldap._tcp.pdc._msdcs.</QueryName>
 			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">wpad</QueryName>
-			<Rule name="Level=3,Desc=Suspicious LDAP Lookup - Useful for identifying tools like sharphound,Risk=90" groupRelation="and">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level==3,Desc=Suspicious LDAP Lookup - Useful for identifying tools like sharphound,Risk=90" groupRelation="and">
 				<QueryName condition="begin with">_ldap.</QueryName>
 				<Image condition="excludes">C:\Windows\</Image>
 				<Image condition="excludes">unknown process</Image>
@@ -5757,7 +5757,7 @@
 			<QueryResults name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">type:  99</QueryResults>
 			<QueryResults name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">type:  33</QueryResults>
 			-->
-			<Image name="Information=Uncategorized Events" condition="contains any">System;svchost.exe;services.exe;unknown process;\;;</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Uncategorized Events" condition="contains any">System;svchost.exe;services.exe;unknown process;\;;</Image>
 		</DnsQuery>
 	</RuleGroup>
 	<RuleGroup name="RG=DNS Query Excludes" groupRelation="or">

--- a/sysmonconfig-cyberkryption.xml
+++ b/sysmonconfig-cyberkryption.xml
@@ -1,0 +1,6208 @@
+<!--
+	   ____                           ___ ________________    _______ __
+	  / __/_ _____ __ _  ___  ___    / _ /_  __/_  __/ __/___/ ___/ //_/
+	 _\ \/ // (_-</  ' \/ _ \/ _ \  / __ |/ /   / /  > _/_ _/ /__/ ,<   
+	/___/\_, /___/_/_/_/\___/_//_/ /_/ |_/_/   /_/  |_____/ \___/_/|_|  
+		/___/                                                           
+	author:	ionstorm
+	project:	https://github.com/ion-storm/sysmon-config
+	license:	Creative Commons Attribution 4.0 | You may privatize, fork, edit, teach, publish, or deploy for commercial use - with attribution in the text.
+	Methodology: Detect the Most Techniques per Data source in MITRE ATT&CK.
+				 Provide Visibility into Forensic Artifact Events for UEBA.
+				 Detect Exploitation events with wide CVE Coverage.
+				 Risk Scoring of CVE, UEBA, Forensic, MITRE ATT&CK Events.
+				 
+				 Primary Tags:
+				 Attack: Mitre ATT&CK Identifier
+				 Technique: Mitre ATT&CK Technique
+				 Tactic: Mitre ATT&CK Tactic
+				 Alert: Alert Text for SIEM/XDR
+				 Info: Informational Alert Text
+				 Level: The level field contains one of five string values. It describes the criticality of a triggered rule. 
+				 While low and medium level events have an informative character, events with high and critical level should 
+				 lead to immediate reviews by security analysts.
+				 Desc: Description of non-alerting UEBA/Behavioral Based Rules
+				 Forensic: Forensic Artifacts
+				 CVE: CVE Vulnerability Identification
+				 FP: False Positive Rate
+				 Author: Author of rule
+				 
+				 Additional Tag Details:
+				 Rapid Response Tags: (for EDR/XDR/SIEM Response & Automation)
+				 kp=y 	Kill process with child processes
+				 kpp=y 	Kill Parent Processes & all Child Processes
+				 kc=y    Kill network connections
+				 ki=y    Kill Injected Thread
+				 sd=y 	Shutdown System
+				 fw=y	Add Windows Firewall Rule to block inbound/outbound network connectivity from process
+				 yara=y  Yara Scan file
+				 ydel=y  Delete on Yara Detection
+				 rf=y    Restore Deleted File
+				 nr=y 	Null route ip
+				 iso=y Isolate Host
+				 SD=y Service Desk Ticket
+				 SOC=y SOC Ticket Creation
+				 
+				 Risk Score ratings: (Risk=??)
+				 Low Risk: 1-39
+				 Medium Risk: 40-69
+				 High Risk: 70-89
+				 Critical Risk: 90-100
+				 
+				 Levels: (from Sigma)
+				 (0) informational: Rule is intended for enrichment of events, e.g. by tagging them. No case or alerting should be triggered 
+				 by such rules because it is expected that a huge amount of events will match these rules.
+				 (1) low: Notable event but rarely an incident. Low rated events can be relevant in high numbers or combination with others. 
+				 Immediate reaction shouldn't be necessary, but a regular review is recommended.
+				 (2) medium: Relevant event that should be reviewed manually on a more frequent basis.
+				 (3) high: Relevant event that should trigger an internal alert and requires a prompt review.
+				 (4) critical: Highly relevant event that indicates an incident. Critical events should be reviewed immediately.
+				 
+				 False Positive Rates: (FP=?)
+				 (0) Zero False Positives rate
+				 (1) Some False Positives rate
+				 (2) Medium False Positive rate
+				 (3) High False Positive rate
+				 
+				 Properly Escape in XML:
+				 < &lt;
+				 > &gt;
+				 " &quot;
+				 ' &apos;
+				 & &amp;
+				 
+				 Other Notes:
+				 The Rulename field has a hard limit of 255 characters, make the best of the size available, shorten tags and descriptions as needed.
+				 Add exclusions in line enclosed within a Compound rule rather than a global exclusion list.
+-->
+<Sysmon schemaversion="4.82">
+	<HashAlgorithms>md5,sha256,imphash</HashAlgorithms> <!-- Both MD5 and SHA256 are the industry-standard algorithms for identifying files -->
+	<CheckRevocation/>
+	<EventFiltering>
+	<!--SYSMON EVENT ID 1 : PROCESS CREATION [ProcessCreate]-->
+	<RuleGroup name="RG=ProcessCreate Include Group" groupRelation="or">
+		<ProcessCreate onmatch="include">
+			<!--MITRE ATT&CK TACTIC: Reconnaissance-->
+			<!--MITRE ATT&CK TECHNIQUE: Active Scanning-->
+			<Rule name="Attack=T1595.002,Technique=Vulnerability Scanning,Tactic=Reconnaissance,Level=3,Alert=Nessus Scan Detected,Risk=100" groupRelation="or">
+				<ParentCommandLine condition="contains any">TEMP\nessus_;nessus_task_list</ParentCommandLine>
+				<CommandLine condition="contains any">TEMP\nessus_;nessus_task_list</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1595.002,Technique=Vulnerability Scanning,Tactic=Reconnaissance,Level=4,Alert=Port Scan Tool Detected,Risk=100" groupRelation="or">
+				<CommandLine condition="contains any">rcpping;tcpping;tcping;routerscan;grabff;Port-Scan;netscan;\nmap;ipscan;nacmdline.exe</CommandLine>
+				<OriginalFileName condition="is any">advanced_port_scanner.exe;rcpping.exe;nc.exe;nc64.exe;netcat.exe;ncat.exe;nmap.exe;zenmap.exe;advanced_ip_scanner.exe</OriginalFileName>
+				<Product condition="contains any">Network Scanner;Advanced IP Scanner</Product>
+			</Rule>
+			<Rule name="Attack=T1087,Technique=Account Discovery,Tactic=Discovery,Level=4,Alert=ADFind.exe Discovery,Risk=100" groupRelation="or">
+				<OriginalFileName condition="contains">adfind</OriginalFileName>
+				<Product condition="contains">adfind</Product>
+				<CommandLine condition="contains any">-gcb -sc;/gcb /sc;-f (objectcategory=;/f (objectcategory=;trustdmp</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Host Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Identity Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Network Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Org Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Phishing for Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Closed Sources-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Open Technical Databases-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Open Websites/Domains-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Victim-Owned Websites-->
+
+			<!--MITRE ATT&CK TACTIC: Resource Development-->
+			<Rule name="Attack=T1587,Technique=Develop Capabilities,Tactic=Resource Development,Alert=PurpleSharp Indicator,Risk=40" groupRelation="or">
+				<CommandLine condition="contains any">PurpleSharp;xyz123456</CommandLine> 
+				<OriginalFileName condition="contains any">PurpleSharp</OriginalFileName> 
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Acquire Infrastructure-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Infrastructure-->
+			<CommandLine name="Attack=T1584.002,Technique=Compromise Infrastructure: DNS Server,Tactic=Resource Development,Level=4,Alert=DNSCMD DLL exec" condition="contains">/serverlevelplugindll</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Develop Capabilities-->
+			<Rule name="Attack=T1587.003,Technique=Develop Capabilities: Digital Certificates,Tactic=Resource Development,Alert=netsh adding SSL Certificate,Risk=40" groupRelation="and">
+				<CommandLine condition="contains all">add;sslcert;http</CommandLine> 
+			</Rule>
+			<CommandLine name="Attack=T1016,Technique=System Network Connections Discovery,Tactic=Discovery,Level=3,Alert=netsh removing SSL Certificate,Risk=40" condition="contains">http del sslcert</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Establish Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Obtain Capabilities-->
+			<!--MITRE ATT&CK TECHNIQUE: Stage Capabilities-->
+
+			<!--MITRE ATT&CK TACTIC: Initial Access-->
+			<Rule name="Attack=T1566.001,Technique=Phishing: Spear Phishing Attachment,Tactic=Initial Access,Level=0,Alert=Executed files within Outlook Attachments,Risk=30" groupRelation="and">
+				<Image condition="contains">C:\Users\</Image>
+				<Image condition="contains">Content.Outlook</Image>
+			</Rule>
+			<Rule name="Attack=T1566.001,Technique=Phishing: Spear Phishing Attachment,Tactic=Initial Access,Level=0,Alert=Arbitrary Shell Command Execution Via Settingcontent-Ms,Risk=30" groupRelation="and">
+				<CommandLine condition="contains">.SettingContent-ms</CommandLine>
+				<CommandLine condition="excludes">immersivecontrolpanel</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1566.001,Technique=Phishing: Spear Phishing Attachment,Tactic=Initial Access,Level=0,Alert=Double File Extension,Risk=100" groupRelation="or">
+				<Image condition="end with">.doc.exe</Image>
+				<Image condition="end with">.docx.exe</Image>
+				<Image condition="end with">.docx.exe</Image>
+				<Image condition="end with">.xls.exe</Image>
+				<Image condition="end with">.xlsx.exe</Image>
+				<Image condition="end with">.ppt.exe</Image>
+				<Image condition="end with">.pptx.exe</Image>
+				<Image condition="end with">.rtf.exe</Image>
+				<Image condition="end with">.pdf.exe</Image>
+				<Image condition="end with">.txt.exe</Image>
+				<Image condition="end with">      .exe</Image>
+				<Image condition="end with">______.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1566.001,Technique=Phishing: Spear Phishing Attachment,Tactic=Initial Access,Level=0,Alert=Suspicious HWP Sub Processes,Risk=70" groupRelation="and">
+				<ParentImage condition="image">Hwp.exe</ParentImage>
+				<Image condition="image">gbb.exe</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Drive-by Compromise-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploit Public-Facing Application-->
+			<Rule name="Attack=T1190,Technique=Exploit Public-Facing Application,Tactic=Initial Access,CVE=CVE-2020-1350,Level=4,Alert=DNS Remote Code Execution,Risk=100" groupRelation="and">
+				<ParentCommandLine condition="contains all">svchost.exe;termsvcs</ParentCommandLine>
+				<Image condition="excludes any">rdpclip.exe;csrss.exe;wininit.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1190,Technique=Exploit Public-Facing Application,Tactic=Initial Access,CVE=CVE-2020-1350,Level=4,Alert=DNS Remote Code Execution,Risk=100" groupRelation="and">
+				<ParentImage condition="image">dns.exe</ParentImage>
+				<Image condition="excludes any">werfault.exe;conhost.exe;dnscmd.exe;dns.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1190,Tactic=Initial Access,Technique=Exploit Public-Facing Application,CVE=CVE-2019-0708,Level=4,Alert=Terminal Service Process Spawn,Risk=100" groupRelation="and">
+				<ParentImage condition="contains any">UMWorkerProcess.exe;UMService.exe</ParentImage>
+				<CommandLine condition="excludes any">perfenabled</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1190,Tactic=Initial Access,Technique=Exploit Public-Facing Application,CVE=CVE-2021-26857,Level=4,Alert=HAFNIUM APT Exchange UMS Process,Risk=100" groupRelation="and">
+				<ParentImage condition="contains any">UMWorkerProcess.exe;UMService.exe</ParentImage>
+				<CommandLine condition="excludes any">perfenabled</CommandLine>
+				<Image condition="excludes any">wemgr.exe;werfault.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1190,Technique=Exploit Public-Facing Application,Tactic=Initial Access,Level=4,Alert=wwwroot Web Server Exploitation Detected,Risk=100" groupRelation="and">
+				<Image condition="contains any">\wwwroot\</Image>
+			</Rule>
+			<Rule name="Attack=T1190,Technique=Exploit Public-Facing Application,Tactic=Initial Access,Level=4,Alert=Atlassian Confluence Remote Exploit,Risk=100,CVE=CVE-2021-26084" groupRelation="and">
+				<ParentImage condition="end with">\Atlassian\Confluence\jre\bin\java.exe</ParentImage>
+				<CommandLine condition="contains any">cmd;powershell;certutil;curl;whoami;ipconfig;mshta;wscript;cscript;rundll32;bitsadmin</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1190,Technique=Exploit Public-Facing Application,Tactic=Initial Access,Level=4,Alert=Generic Java Webapp Remote Exploit,Risk=100" groupRelation="and">
+				<ParentImage condition="image">\jre\bin\java.exe</ParentImage>
+				<Image condition="contains any">cmd;powershell;pwsh;certutil;curl;whoami;ipconfig;mshta;wscript;cscript;rundll32;bitsadmin;pwsh.exe;bitsadmin;hh.exe;wmic.exe;rundll32.exe;forfiles.exe;scriptrunner.exe;mftrace.exe;AppVLP.exe;curl.exe</Image>
+				<!--Allow Confluence Rule to fire-->
+				<ParentImage condition="excludes">\Atlassian\Confluence\jre\bin\java.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1190,Technique=Exploit Public-Facing Application,Tactic=Initial Access,Level=4,Alert=Generic Java keytool Exploit,Risk=100" groupRelation="and">
+				<ParentImage condition="image">keytool.exe</ParentImage>
+				<Image condition="contains any">cmd;powershell;pwsh;certutil;curl;whoami;ipconfig;mshta;wscript;cscript;rundll32;bitsadmin;pwsh.exe;bitsadmin;hh.exe;wmic.exe;rundll32.exe;forfiles.exe;scriptrunner.exe;mftrace.exe;AppVLP.exe;curl.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1190,Technique=Exploit Public-Facing Application,Tactic=Initial Access,Level=4,Alert=Apache Spark Exploit,CVE=CVE-2022-33891,Risk=100" groupRelation="and">
+				<ParentImage condition="contains any">bash.exe;cmd.exe;powershell.exe;pwsh.exe</ParentImage>
+				<CommandLine condition="contains any">id -Gn `;id /Gn `;id -Gn ';id /Gn '</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: External Remote Services-->
+			<Rule name="Attack=T1133,Technique=External Remote Services,Tactic=Initial Access,Level=2,Alert=Screenconnect Remote Access,Risk=50" groupRelation="and">
+				<CommandLine condition="contains all">e=Access&amp;;y=Guest&amp;;&amp;p=;&amp;c=;&amp;k=</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Hardware Additions-->
+			<!--MITRE ATT&CK TECHNIQUE: Phishing-->
+			<!--MITRE ATT&CK TECHNIQUE: Replication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Supply Chain Compromise-->
+			<!--MITRE ATT&CK TECHNIQUE: Trusted Relationship-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts -->
+			
+			<!--MITRE ATT&CK TACTIC: Execution-->
+			<Rule name="Attack=T1047,Technique=Windows Management Instrumentation,Tactic=Execution,Level=3,Alert=WMI Execution Detected,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">wmic.exe</OriginalFileName>
+				<CommandLine condition="contains all">process;call;create</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1047,Technique=Windows Management Instrumentation,Tactic=Execution,Level=3,Alert=Suspicious WMIC Commands,Risk=30" groupRelation="and">
+				<OriginalFileName condition="contains">wmic.exe</OriginalFileName>
+				<CommandLine condition="contains any">call set priority;call terminate;product get name;bios, get serialNumber;BIOS GET SERIALNUMBER;onboarddevice get;useraccount where name;useraccount get;path win32_networkadapter where index=;process list;useraccount get /ALL;useraccount list;qfe get description,installedOn /format:csv;process get caption,executablepath,commandline;service get name,displayname,pathname,startmode;share list;win32_share</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter-->
+			<Rule name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=3,Alert=Suspicious Console Host Execution Locations,Risk=30" groupRelation="and">
+				<ParentImage condition="contains any">C:\Users\;$Recycle;\Temp\;\Downloads\</ParentImage>
+				<CommandLine condition="is">\??\C:\WINDOWS\system32\conhost.exe 0xffffffff -ForceV1</CommandLine>
+				<Image condition="image">conhost.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=3,Alert=Suspicious Console Host Parents,Risk=30" groupRelation="and">
+				<ParentImage condition="contains any">svchost.exe;lsass.exe;services.exe;smss.exe;winlogon.exe;explorer.exe;dllhost.exe;rundll32.exe;regsvr32.exe;userinit.exe;winit.exe;spoolsv.exe;wermgr.exe;csrss.exe;ctfmon.exe;werfault.exe</ParentImage>
+				<Image condition="image">conhost.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=3,Alert=Suspicious Console Host children,Risk=30" groupRelation="and">
+				<ParentImage condition="image">conhost.exe</ParentImage>
+				<Image condition="excludes any">:\Windows\splwow64.exe;:\Windows\System32\WerFault.exe;:\Windows\System32\conhost.exe</Image>
+			</Rule>
+			<!-- Disabled for now
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,UEBA=Execution Command Line tools by user,Risk=45" groupRelation="and">
+				<Image condition="contains any">\cmd.exe;WindowsTerminal;powershell</Image>
+				<ParentImage condition="image">explorer.exe</ParentImage>
+			</Rule>
+			-->
+			<Rule name="Attack=T1059.001,Technique=Powershell,Tactic=Execution,UEBA=Powershell as cmd.exe child process,Risk=39" groupRelation="and">
+				<ParentImage condition="image">cmd.exe</ParentImage>
+				<Image condition="contains any">powershell.exe;powershell_ise.exe</Image>
+				<CommandLine condition="excludes">Get-ItemProperty HKLM:\software\wow6432node\microsoft\windows\currentversion\uninstall\</CommandLine>
+				<CommandLine condition="excludes">mysql server</CommandLine>
+				<CommandLine condition="excludes">select-object displayversion,displayname</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1059.001,Technique=Powershell,Tactic=Execution,Level=3,Alert=Powershell ran from Scripting Utilities,Risk=50" groupRelation="and">
+				<ParentImage condition="contains any">cscript.exe;wscript.exe</ParentImage>
+				<Image condition="contains any">powershell.exe;powershell_ise.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1059.001,Technique=Powershell,Tactic=Execution,Level=3,Alert=Powershell ran from cscript or wscript,Risk=50" groupRelation="and">
+				<ParentImage condition="contains any">cscript.exe;wscript.exe</ParentImage>
+				<Image condition="contains any">powershell.exe;powershell_ise.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1059,Technique=Scripting,Tactic=Execution,Level=4,Alert=Powershell Launched from mshta,Risk=100" groupRelation="and">
+				<Image condition="contains any">powershell.exe;powershell_ise.exe</Image>
+				<ParentImage condition="image">mshta.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1059,Technique=Visual Basic,Tactic=Execution,UEBA=Suspicious WSCRIPT Command Line,Risk=50" groupRelation="and">
+				<Image condition="contains any">wscript.exe;cscript.exe</Image>
+				<CommandLine condition="excludes any">IEX;Net.WebClient;ospp.vbs;powershell;slmgr.vbs;spiceworks_upload</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1059,Technique=Scripting,Tactic=Execution,Level=2,Alert=Suspicious wscript commands,Risk=60" groupRelation="and">
+				<Image condition="image">wscript.exe</Image>
+				<CommandLine condition="contains">.jse</CommandLine>
+				<CommandLine condition="contains">.js</CommandLine>
+				<CommandLine condition="contains">.vba</CommandLine>
+				<CommandLine condition="contains">.vbe</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1059,Technique=Scripting,Tactic=Execution,Level=2,Alert=cscript execution,Risk=60" groupRelation="and">
+				<Image condition="image">cscript.exe</Image>
+				<CommandLine condition="contains">.js</CommandLine>
+				<CommandLine condition="contains">.jse</CommandLine>
+				<CommandLine condition="contains">.vba</CommandLine>
+				<CommandLine condition="contains">.vbe</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1059,Technique=Scripting,Tactic=Execution,Level=4,Alert=Suspicious or Malicious mshta exec,Risk=70" groupRelation="and">
+				<CommandLine condition="contains any">mshta vbscript:CreateObject("Wscript.Shell");mshta vbscript:Execute("Execute;mshta vbscript:CreateObject("Wscript.Shell").Run("mshta.exe;javascript:a=</CommandLine>
+				<CommandLine condition="contains any">.jpg;.png;.lnk;.xls;.doc;.zip;.sct;.hta</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1059.003,Technique=Scripting,Tactic=Execution,Level=4,Alert=Possible WinNTI Malware,Risk=100" groupRelation="and">
+				<ParentImage condition="contains any">C:\Windows\Temp\hpqhvind.exe;C:\ProgramData\DRM\;Test.exe</ParentImage>
+				<Image condition="contains any">C:\ProgramData\DRM;wmplayer.exe;C:\ProgramData\DRM\CLR\CLR.EXE</Image>
+			</Rule>
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,UEBA=Registry Editor Opened by user,Risk=70" groupRelation="and">
+				<Image condition="image">regedit.exe</Image>
+				<ParentImage condition="image">explorer.exe</ParentImage>
+			</Rule>
+			<!-- Disabled for now
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Generic User Execution,Risk=1" groupRelation="and">
+				<ParentImage condition="image">explorer.exe</ParentImage>
+			</Rule>
+			-->
+			<Rule name="UEBA=Unusual Child Process,Risk=30" groupRelation="and">
+				<Image condition="is any">svchost.exe;taskhostw.exe;userinit.exe;smss.exe;csrss.exe;wininit.exe;winlogon.exe;lsass.exe;logonui.exe;services.exe</Image>
+				<Image condition="contains any">C:\windows\System32\;C:\windows\syswow64\</Image>
+				<ParentImage condition="excludes any">wininit.exe;winlogon.exe;services.exe;dwm.exe;System;smss.exe;svchost.exe</ParentImage>
+			</Rule>
+			<Rule name="UEBA=Unusual Print Spooler Child Process,Risk=30" groupRelation="and">
+				<ParentImage condition="contains any">\spoolsv.exe;\PrintIsolationHost.exe</ParentImage>
+				<Image condition="excludes any">C:\Windows\System32\spoolsv.exe;\GPLGS\gswin32c.exe;C:\Windows\System32\spool\drivers\;\bin\gswin64c.exe;C:\PROGRA~2\CUTEPD~1\;C:\Windows\EEFPrinter.exe</Image>
+				<CommandLine condition="excludes any">C:\Windows\system32\spool\DRIVERS</CommandLine>
+				<Company condition="excludes any">Brother Industries;Thomson Reuters</Company>
+			</Rule>
+			<ParentCommandLine name="Attack=T1059.001,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=4,Alert=Metasploit Detection,Risk=90" condition="contains">COMSPEC</ParentCommandLine>
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">ScriptFile</CommandLine>
+			<CommandLine name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Execution from Archive File,Risk=50" condition="contains">AppData\Local\Temp\7z</CommandLine><!-- exec from 7zip -->
+			<CommandLine name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Execution from Archive File,Risk=50" condition="contains">AppData\Local\Temp\Temp1_</CommandLine><!-- exec from explorer -->
+			<CommandLine name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Execution from Archive File,Risk=50" condition="contains">\AppData\Local\Temp\Rar$</CommandLine><!-- exec from winrar -->
+			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter: Powershell-->
+			<Rule name="Attack=T1059.001,Technique=Scripting,Tactic=Execution,Level=3,Alert=Powershell Launched from users folder,Risk=60" groupRelation="and">
+				<Image condition="contains any">powershell.exe;powershell_ise.exe</Image>
+				<ParentImage condition="begin with">C:\users\</ParentImage>
+				<ParentImage condition="excludes">Microsoft VS Code\Code.exe</ParentImage>
+				<ParentImage condition="excludes">\Deployment tool extract\setupodt.exe</ParentImage>
+			</Rule>
+			<CommandLine name="Attack=T1059.001,Technique=PowerShell,Tactic=Execution,Level=4,Alert=invoke-shellcode,Risk=100" condition="contains">Shellcode</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter: Python-->
+			<Image name="Level=4,Alert=IronPython,Tactic=Privilege Escalation" condition="image">ipy.exe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">python.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter: Javascript-->
+			<CommandLine name="Attack=T1059.007,Technique=PowerShell,Tactic=Execution,Level=3,Alert=JAVA DLL exec" condition="contains">-agentpath:</CommandLine>
+			<CommandLine name="Attack=T1059.007,Technique=PowerShell,Tactic=Execution,Level=3,Alert=JAVA DLL exec" condition="contains">-agentlib:</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Container Administration Command-->
+			<!--MITRE ATT&CK TECHNIQUE: Deploy Container-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Client Execution-->
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=Browser Exploitation Detected,Risk=90" groupRelation="and">
+				<ParentImage condition="contains any">iexplore.exe;chrome.exe;firefox.exe;browser_broker.exe;vivaldi.exe;microsoftedge.exe;microsoftedgecp.exe;brave.exe;vivaldi.exe</ParentImage>
+				<Image condition="contains any">tracert.exe;csc.exe;cscript.exe;wscript.exe;cmd.exe;powershell.exe;bash.exe;scrcons.exe;schtasks.exe;hh.exe;regsvr32.exe;regsvcs.exe;sh.exe;wmic.exe;mshta.exe;rundll32.exe;msiexec.exe;forfiles.exe;scriptrunner.exe;mftrace.exe;AppVLP.exe;svchost.exe;MicroScMgmt.exe;FLTLDR.exe;wmic.exe;Microsoft.Workflow.Compiler.exe;atbroker.exe;bginfo.exe;certutil.exe;csi.exe;dnx.exe;cdb.exe;bitsadmin.exe;forfiles.exe;fsi.exe;ftp.exe;hostname.exe;gpresult.exe;ipconfig.exe;nbtstat.exe;ping.exe;pwsh.exe;qprocess.exe;quser.exe;qwinsta.exe;reg.exe;svchost.exe;installutil.exe;pwsh.exe;msxsl.exe;ieexec.exe;msdt.exe;verclsid.exe</Image>
+				<ParentCommandLine condition="excludes any">apt-config</ParentCommandLine>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=Office Exploitation Detection,Risk=100" groupRelation="and">
+				<ParentImage condition="contains any">winword.exe;excel.exe;powerpnt.exe;outlook.exe;msaccess.exe;mspub.exe;visio.exe;notepad.exe;wordpad.exe;eqnedt32.exe</ParentImage>
+				<Image condition="contains any">tracert.exe;csc.exe;cscript.exe;wscript.exe;cmd.exe;powershell.exe;bash.exe;scrcons.exe;schtasks.exe;hh.exe;regsvr32.exe;regsvcs.exe;sh.exe;wmic.exe;mshta.exe;rundll32.exe;msiexec.exe;forfiles.exe;scriptrunner.exe;mftrace.exe;AppVLP.exe;svchost.exe;MicroScMgmt.exe;FLTLDR.exe;wmic.exe;Microsoft.Workflow.Compiler.exe;atbroker.exe;bginfo.exe;certutil.exe;csi.exe;dnx.exe;cdb.exe;bitsadmin.exe;forfiles.exe;fsi.exe;ftp.exe;hostname.exe;gpresult.exe;ipconfig.exe;nbtstat.exe;ping.exe;pwsh.exe;qprocess.exe;quser.exe;qwinsta.exe;reg.exe;svchost.exe;installutil.exe;pwsh.exe;msxsl.exe;ieexec.exe;msdt.exe;verclsid.exe</Image>
+				<CommandLine condition="excludes all">.cmd;-</CommandLine>
+				<CommandLine condition="excludes">C:\Windows\system32\spool\DRIVERS\</CommandLine>
+				<CommandLine condition="excludes">PhotoViewer.dll</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Alert=Office Spawning exe within: User Home Dirs,Risk=80" groupRelation="and">
+				<ParentImage condition="contains any">winword.exe;excel.exe;powerpnt.exe;outlook.exe;msaccess.exe;mspub.exe;visio.exe;notepad.exe;wordpad.exe;eqnedt32.exe</ParentImage>
+				<Image condition="begin with">C:\Users\</Image>
+				<Image condition="end with">.exe</Image>
+				<Product condition="excludes">Zoom Video</Product>
+				<Product condition="excludes">Firefox</Product>
+				<Product condition="excludes">Microsoft Edge</Product>
+				<Product condition="excludes">Microsoft Teams</Product>
+				<Image condition="excludes">GrammarlyAddInSetupe</Image>
+				<Image condition="excludes">Teams.exe</Image>
+				<Image condition="excludes">Zoom.exe</Image>
+				<Image condition="excludes">browser_broker.exe</Image>
+				<Image condition="excludes">chrome.exe</Image>
+				<Image condition="excludes">edge.exe</Image>
+				<Image condition="excludes">firefox.exe</Image>
+				<Image condition="excludes">iexplore.exe</Image>
+				<Image condition="excludes">vivaldi.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Info=Office Spawning exe within: ProgramData,Risk=70" groupRelation="and">
+				<ParentImage condition="contains any">winword.exe;excel.exe;powerpnt.exe;outlook.exe;msaccess.exe;mspub.exe;visio.exe;notepad.exe;wordpad.exe</ParentImage>
+				<Image condition="begin with">C:\ProgramData\</Image>
+				<Product condition="excludes">Firefox</Product>
+				<Product condition="excludes">Microsoft Edge</Product>
+				<Product condition="excludes">Microsoft Teams</Product>
+				<Product condition="excludes">Zoom Video</Product>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=3,Alert=Adobe Exploitation Detection,Risk=80" groupRelation="and">
+				<ParentImage condition="contains any">acrobat.exe;acrord32.exe</ParentImage>
+				<Image condition="contains any">tracert.exe;csc.exe;cscript.exe;wscript.exe;cmd.exe;powershell.exe;bash.exe;scrcons.exe;schtasks.exe;hh.exe;regsvr32.exe;regsvcs.exe;sh.exe;wmic.exe;mshta.exe;rundll32.exe;msiexec.exe;forfiles.exe;scriptrunner.exe;mftrace.exe;AppVLP.exe;svchost.exe;MicroScMgmt.exe;FLTLDR.exe;wmic.exe;Microsoft.Workflow.Compiler.exe;atbroker.exe;bginfo.exe;certutil.exe;csi.exe;dnx.exe;cdb.exe;bitsadmin.exe;forfiles.exe;fsi.exe;ftp.exe;hostname.exe;gpresult.exe;ipconfig.exe;nbtstat.exe;ping.exe;pwsh.exe;qprocess.exe;quser.exe;qwinsta.exe;reg.exe;svchost.exe;installutil.exe;pwsh.exe;msxsl.exe;ieexec.exe;msdt.exe;verclsid.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=Web Server Exploitation Detected,Risk=100" groupRelation="and">
+				<ParentImage condition="contains any">apache;w3wp.exe;php-cgi.exe;nginx.exe;httpd.exe;tomcat;php.exe</ParentImage>
+				<Image condition="contains any">arp.exe;at.exe;cscript.exe;wscript.exe;cmd.exe;powershell.exe;bash.exe;scrcons.exe;schtasks.exe;hh.exe;regsvr32.exe;sh.exe;ping.exe;whoami.exe;net.exe;net1.exe;systeminfo.exe;bitsadmin.exe;dsget.exe;dsquery.exe;find.exe;findstr.exe;fsutil.exe;hostname.exe;ipconfig.exe;nbtstat.exe;net.exe;net1.exe;netdom.exe;netsh.exe;netstat.exe;nltest.exe;nslookup.exe;ntdutil.exe;pathping.exe;qprocess.exe;query.exe;qwinsta.exe;reg.exe;rundll32.exe;sc.exe;schtasks.exe;systeminfo.exe;tasklist.exe;tracert.exe;ver.exe;vssadmin.exe;wevtutil.exe;whoami.exe;wmic.exe;wusa.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=Web Server Spawned cmd shell,Risk=100" groupRelation="and">
+				<Image condition="image">cmd.exe</Image>				
+				<CommandLine condition="excludes any">ping 127.0.0.1</CommandLine>				
+				<CurrentDirectory condition="is">c:\windows\system32\inetsrv\</CurrentDirectory>				
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=0,Desc=SQL Server Exploitation Detected,Risk=100" groupRelation="and">
+				<ParentImage condition="contains any">sqlservr</ParentImage>
+				<Image condition="contains any">arp.exe;at.exe;cscript.exe;wscript.exe;cmd.exe;powershell;bash.exe;scrcons.exe;schtasks.exe;hh.exe;regsvr32.exe;sh.exe;ping.exe;whoami.exe;net.exe;net1.exe;systeminfo.exe;bitsadmin.exe;dsget.exe;dsquery.exe;find.exe;findstr.exe;fsutil.exe;hostname.exe;ipconfig.exe;nbtstat.exe;net.exe;net1.exe;netdom.exe;netsh.exe;netstat.exe;nltest.exe;nslookup.exe;ntdutil.exe;pathping.exe;qprocess.exe;query.exe;qwinsta.exe;reg.exe;rundll32.exe;sc.exe;schtasks.exe;systeminfo.exe;tasklist.exe;tracert.exe;ver.exe;vssadmin.exe;wevtutil.exe;whoami.exe;wmic.exe;wusa.exe;sh.exe;bash.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=3,Alert=Office MSHTML Exploit,Risk=100,CVE=CVE-2021-40444" groupRelation="and">
+				<ParentImage condition="contains any">winword.exe;powerpnt.exe;excel.exe</ParentImage>
+				<Image condition="is">control.exe</Image>
+				<CommandLine condition="excludes any">input.dll</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=Follina msdt Exploit,Risk=100,CVE=CVE-2022-30190" groupRelation="and">
+				<Image condition="is">msdt.exe</Image>
+				<OriginalFileName condition="is">msdt.exe</OriginalFileName>
+				<CommandLine condition="contains all">BrowseForFile=;PCWDiagnostic</CommandLine>
+				<CommandLine condition="contains any">/af;-af</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=msdt via answer file,Risk=100,CVE=CVE-2022-30190" groupRelation="and">
+				<Image condition="is">msdt.exe</Image>
+				<ParentImage condition="is not">pcwrun.exe</ParentImage>
+				<CommandLine condition="contains">PCWDiagnostic</CommandLine>
+				<CommandLine condition="contains any">/af;-af</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=msdt via diagcab file,Risk=100,CVE=CVE-2022-30190" groupRelation="and">
+				<Image condition="is">msdt.exe</Image>
+				<CommandLine condition="contains any">/cab;-cab</CommandLine>
+				<CommandLine condition="contains">.diagcab</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=MSDT Executed with Suspicious Parent,Risk=100,CVE=CVE-2022-30190" groupRelation="and">
+				<ParentImage condition="contains any">powershell.exe;pwsh.exe;cmd.exe;mshta.exe;cscript.exe;wscript.exe;wsl.exe;rundll32.exe;regsvr32.exe</ParentImage>
+				<Image condition="is">msdt.exe</Image>
+			</Rule>
+			<ParentImage condition="image" name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=3,Alert=Exploit - Equation Editor starts application,CVE=CVE-2017-11882">EQNEDT32.EXE</ParentImage> <!-- https://app.any.run/tasks/dfea0112-6fbe-4091-9161-1e8f25f611b0/-->
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=3,Alert=EPS Processing 0day,Risk=100,CVE=CVE-2017-0261" groupRelation="and">
+				<ParentImage condition="contains any">winword.exe;excel.exe;powerpnt.exe</ParentImage>
+				<Image condition="is">FLTLDR.EXE</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Inter-Process Communication-->
+			<CommandLine name="Attack=T1559.002,Technique=Dynamic Data Exchange,Tactic=Execution" condition="contains any">/dde;-dde</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Native API-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<Rule name="Attack=T1053,Technique=Scheduled Task,Tactic=Execution,Level=2,Alert=Scheduled Task Created,Risk=100" groupRelation="and">
+				<Image condition="image">schtasks.exe</Image>
+				<CommandLine condition="contains any">/create;-create;/change;-change</CommandLine>
+				<CurrentDirectory condition="excludes">C:\Program Files\Common Files\Microsoft Shared\ClickToRun\</CurrentDirectory>
+			</Rule>
+			<OriginalFileName name="Attack=T1053,Technique=Scheduled Task,Tactic=Execution,Level=2,Alert=Scheduled Task Created,Risk=1" condition="is">taskeng.exe</OriginalFileName>
+			<Rule name="Attack=T1053,Technique=Scheduled Task,Tactic=Execution,Level=0,Desc=Schtasks task Run,Risk=60" groupRelation="and">
+				<Image condition="image">schtasks.exe</Image>
+				<CommandLine condition="contains any">/Run;-run</CommandLine>
+				<CommandLine condition="excludes">Sentinel\AutoRepair</CommandLine>
+				<CurrentDirectory condition="excludes">C:\Program Files\Common Files\Microsoft Shared\ClickToRun\</CurrentDirectory>
+			</Rule>
+			<Rule name="Attack=T1053,Technique=Scheduled Task,Tactic=Persistence,Level=2,Alert=Child process from schtasks" groupRelation="and">
+				<ParentImage condition="image">schtasks.exe</ParentImage>
+			</Rule>
+			<Image name="Attack=T1053,Technique=Scheduled Task,Tactic=Persistence,Level=2,Alert=at.exe Task scheduler execution" condition="image">at.exe</Image>
+			<ParentImage name="Attack=T1053,Technique=Scheduled Task,Tactic=Execution/Persistence/Privledge Escalation,Level=2,Alert=at.exe Task scheduler execution" condition="image">at.exe</ParentImage>
+			<Rule name="Attack=T1053,Technique=Scheduled Task,Tactic=Execution,Level=0,Desc=Scheduled Task Started,Risk=0" groupRelation="and">
+				<ParentImage condition="image">C:\Windows\System32\svchost.exe</ParentImage>
+				<ParentCommandLine condition="contains all">netsvcs;-p;-s;Schedule</ParentCommandLine>
+				<CommandLine condition="excludes all">netsvcs;-p;-s;Schedule</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Shared Modules-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Deployment Tools-->
+			<!--MITRE ATT&CK TECHNIQUE: System Services-->
+			<Rule name="Attack=T1569.002,Technique=Service Execution,Tactic=Execution,Level=0,Desc=Service Stop detected,Risk=0" groupRelation="and">
+				<OriginalFileName condition="contains any">net.exe;net1.exe;net2.exe</OriginalFileName>
+				<CommandLine condition="contains">stop</CommandLine>
+				<ParentCommandLine condition="excludes">tvsu_tmp</ParentCommandLine>
+			</Rule>
+			<Rule name="Attack=T1569.002,Technique=Service Execution,Tactic=Execution,Level=0,Desc=NET.EXE Service Start detected,Risk=30" groupRelation="and">
+				<OriginalFileName condition="contains any">net.exe;net1.exe;net2.exe</OriginalFileName>
+				<CommandLine condition="contains">start</CommandLine>
+				<ParentCommandLine condition="excludes">tvsu_tmp</ParentCommandLine>
+			</Rule>
+			<Rule name="Attack=T1569.002,Technique=Service Execution,Tactic=Execution/Lateral Movement,Level=3,Alert=Impacket Detection 1,Risk=100" groupRelation="and">
+				<ParentImage condition="contains any">wmiprvse.exe;mmc.exe;explorer.exe;services.exe</ParentImage>
+				<CommandLine condition="contains all">&#38;1;cmd.exe;\\127.0.0.1\;/Q /c</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1569.002,Technique=Service Execution,Tactic=Execution/Lateral Movement,Level=3,Alert=Impacket Detection 2,Risk=100" groupRelation="and">
+				<ParentImage condition="contains any">wmiprvse.exe;mmc.exe;explorer.exe;services.exe</ParentImage>
+				<CommandLine condition="contains all">&#38;1;cmd.exe;\\127.0.0.1\;-Q -c</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1035,Technique=Service Execution,Tactic=Execution/Lateral Movement,Level=4,Alert=PowerSploit/Empire Persistence,Risk=100" groupRelation="and">
+				<CommandLine condition="contains all">schtasks;Create;ONLOGON;TN;Updater;TR;powershell</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1543.003,Technique=Windows Service,Tactic=Persistence/Privilege Escalation,Level=2,Alert=Service added via SC,Risk=100" groupRelation="and">
+				<Image condition="image">sc.exe</Image>
+				<CommandLine condition="contains">create</CommandLine>
+				<CurrentDirectory condition="excludes any">\NIC_Emulex_Firmware\;C:\Windows\Temp\ExchangeSetup\</CurrentDirectory>
+			</Rule>
+			<Rule name="Attack=T1543.003,Technique=Windows Service,Tactic=Persistence/Privilege Escalation,Level=2,Alert=Service binpath modification,Risk=100" groupRelation="and">
+				<Image condition="image">sc.exe</Image>
+				<CommandLine condition="contains all">config;binpath</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1543.003,Technique=Windows Service,Tactic=Privilege Escalation,Level=3,Alert=Shell as System Service,Risk=100" groupRelation="and">
+				<Image condition="contains any">cmd.exe;powershell.exe</Image>
+				<ParentImage condition="image">services.exe</ParentImage>
+			</Rule>
+			<CommandLine name="Attack=T1543.003,Technique=Windows Service,Tactic=Persistence,Level=2,Alert=Service added via Powershell,Risk=50" condition="contains">new-service</CommandLine>
+			<ParentImage name="Attack=T1035,Technique=Service Execution,Tactic=Execution/Lateral Movement,Level=4,Alert=PSEXESVC Child Process,Risk=100" condition="image">psexesvc.exe</ParentImage>
+			<Rule name="Attack=T1035,Technique=Service Execution,Tactic=Execution/Lateral Movement,Level=4,Alert=PSexec Execution,Risk=100" groupRelation="or">
+				<Description condition="contains">Execute processes remotely</Description>
+				<Image condition="contains">psexe</Image><!--Detect PSExec, PSexec services-->
+				<Description condition="contains">PsExec Service</Description> 
+				<Description condition="contains">PsExec Launched</Description> 
+			</Rule>
+			<Rule name="Attack=T1035,Technique=Service Execution,Tactic=Execution/Lateral Movement,Level=4,Alert=Sysinternals Initial Tool Execution,Risk=100" groupRelation="or">
+				<CommandLine condition="contains">accepteula</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1035,Technique=Service Execution,Tactic=Execution/Lateral Movement,Level=4,Alert=PSexec SYSTEM Execution,Risk=100" groupRelation="and">
+				<Description condition="contains">Execute processes remotely</Description>
+				<CommandLine condition="contains any">-s;/s</CommandLine>
+			</Rule>
+			<ParentImage name="Attack=T1035,Technique=Service Execution,Tactic=Execution/Lateral Movement,Level=4,Alert=PSexec Child Process,Risk=100" condition="image">psexec.exe</ParentImage>
+			<ParentImage name="Attack=T1035,Technique=Service Execution,Tactic=Execution/Lateral Movement,Level=2,Alert=PSKill Execution,Risk=100" condition="image">pskill.exe</ParentImage>
+			<Image name="Attack=T1035,Technique=Service Execution,Tactic=Execution,Level=2,Alert=PsKill Command" condition="contains">pskill</Image><!--Detect pskill-->
+			<Rule name="Attack=T1569.002,Technique=System Services,Tactic=Execution,Level=3,Alert=Remote Procedure Call Service Anomaly,Risk=75" groupRelation="and">
+				<ParentCommandLine condition="contains all">C:\WINDOWS\system32\svchost.exe;RPCSS</ParentCommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: User Execution-->
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=3,Alert=AstraRoth Command Line detection" groupRelation="and">
+				<CommandLine condition="contains">&amp;&amp; type</CommandLine>
+				<CommandLine condition="contains">&gt;</CommandLine>
+				<CommandLine condition="contains">cmd.exe" /c cd</CommandLine>
+			</Rule>
+			<Rule  name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=3,Alert=Suspicious or Malicious Command Line events" groupRelation="and">
+				<CommandLine condition="contains any">ntdsutil;/set {default} recoveryenabled no;telnet ;-dumpcr;putty;bash.exe;pssh;shareenum;sekurlsa;reg save;reg  save;psscan;shellexec;vbscript:createobject;/output:clipboard;root\\default;root\\subscription;Wmiclass;WmiCl'+'as'+'s</CommandLine>
+			</Rule>
+			<Rule  name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Powershell Suspicious or Malicious events" groupRelation="or">
+				<CommandLine condition="contains any">ERROR kuhl;windows/meterpreter;InjectDLL;ReflectiveLoader;Koadic.;@subtee;-donate-level=;stratum+tcp;Win32_TaskService;FilterToConsumerBinding;Invoke-Stager;Invoke-FruityC2;smbscanner;Invoke-ReverseDNSLookup;Invoke-ARPScan;Invoke-Paranoia;Find-TrustedDocuments;Find-Fruit;Get-RickAstley;PowerView;Invoke-Tater;Get-System;Get-SiteListPassword;PowerBreach;Invoke-BackdoorLNK;Install-SSP;Get-SecurityPackages;Invoke-SSHCommand;Invoke-PsExec;Invoke-InveighRelay;Set-Wallpaper;Invoke-VoiceTroll;Invoke-ThunderStruck;Exploit-Jboss;Invoke-PowerDump;Invoke-DCSync;Get-VaultCredential;Set-MacAttribute;New-HoneyHash;MailRaider;Invoke-RunAs;Invoke-PSInject;Invoke-EgressCheck;Invoke-NetRipper;Invoke-Inveigh;Get-Screenshot;Get-IndexedItem;Get-FoxDump'Get-Clipboard;Get-ChromeDump;Start-CaptureServer;Add-Persistence;Add-Exfiltration;Invoke-PowerShellWMI;Invoke-PowerShellTCP;Invoke-PoshRatHttp;Show-TargetScreen;Get-PassHashes;Get-LSASecret;Check-VM;Remove-Update;Enabled-DuplicateToken;Invoke-ADSBackdoor;Gupt-Backdoor;Add-ScrnSaveBackdoor;Add-RegBackdoor;Get-Unconstrained;Get-RegAlwaysInstallElevated;Get-ApplicationHost;Get-WebConfig;Get-UnattendedInstallFile;Get-VulnAutoRun;Get-RegAutoLogon;Install-ServiceBinary;Invoke-ServiceAbuse;Get-ServicePermission;Get-ServiceFilePermission;Get-ServiceUnquoted;Invoke-DowngradeAccount;Invoke-ACLScanner;Find-GPOLocation;Invoke-UserHunter;Invoke-ReflectivePEInjectionInvoke-ReflectivePEInjection;Invoke-ReflectivePEInjection;VolumeShadowCopyTools;Out-Minidump;Invoke-TokenManipulation;Invoke-DllInjection;Invoke-SessionGopher;Invoke-Shellcode;Invoke-WmiCommand;Get-GPPPassword;Get-Keystrokes;Get-TimedScreenshot;Get-VaultCredential;Invoke-CredentialInjection;Invoke-NinjaCopy</CommandLine>
+				<ParentCommandLine condition="contains any">ERROR kuhl;windows/meterpreter;InjectDLL;ReflectiveLoader;Koadic.;@subtee;-donate-level=;stratum+tcp;Win32_TaskService;FilterToConsumerBinding;Invoke-Stager;Invoke-FruityC2;smbscanner;Invoke-ReverseDNSLookup;Invoke-ARPScan;Invoke-Paranoia;Find-TrustedDocuments;Find-Fruit;Get-RickAstley;PowerView;Invoke-Tater;Get-System;Get-SiteListPassword;PowerBreach;Invoke-BackdoorLNK;Install-SSP;Get-SecurityPackages;Invoke-SSHCommand;Invoke-PsExec;Invoke-InveighRelay;Set-Wallpaper;Invoke-VoiceTroll;Invoke-ThunderStruck;Exploit-Jboss;Invoke-PowerDump;Invoke-DCSync;Get-VaultCredential;Set-MacAttribute;New-HoneyHash;MailRaider;Invoke-RunAs;Invoke-PSInject;Invoke-EgressCheck;Invoke-NetRipper;Invoke-Inveigh;Get-Screenshot;Get-IndexedItem;Get-FoxDump'Get-Clipboard;Get-ChromeDump;Start-CaptureServer;Add-Persistence;Add-Exfiltration;Invoke-PowerShellWMI;Invoke-PowerShellTCP;Invoke-PoshRatHttp;Show-TargetScreen;Get-PassHashes;Get-LSASecret;Check-VM;Remove-Update;Enabled-DuplicateToken;Invoke-ADSBackdoor;Gupt-Backdoor;Add-ScrnSaveBackdoor;Add-RegBackdoor;Get-Unconstrained;Get-RegAlwaysInstallElevated;Get-ApplicationHost;Get-WebConfig;Get-UnattendedInstallFile;Get-VulnAutoRun;Get-RegAutoLogon;Install-ServiceBinary;Invoke-ServiceAbuse;Get-ServicePermission;Get-ServiceFilePermission;Get-ServiceUnquoted;Invoke-DowngradeAccount;Invoke-ACLScanner;Find-GPOLocation;Invoke-UserHunter;Invoke-ReflectivePEInjectionInvoke-ReflectivePEInjection;Invoke-ReflectivePEInjection;VolumeShadowCopyTools;Out-Minidump;Invoke-TokenManipulation;Invoke-DllInjection;Invoke-SessionGopher;Invoke-Shellcode;Invoke-WmiCommand;Get-GPPPassword;Get-Keystrokes;Get-TimedScreenshot;Get-VaultCredential;Invoke-CredentialInjection;Invoke-NinjaCopy</ParentCommandLine>
+			</Rule>
+			<CommandLine name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Ramnit Banker Malware,Risk=100" condition="contains">--disable-http2 --disable-quic</CommandLine>
+			<CommandLine name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=DNSpionage Link click,Risk=100" condition="contains">/Client/Login?id=</CommandLine>
+			<ParentCommandLine name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=4,Alert=Emotet Child Process Detected" condition="contains">JABzA</ParentCommandLine>
+			<!--Suspicious/Malicious Hash Detection-->
+			<Rule  name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Malicious Hash Detected" groupRelation="or">
+				<Hashes condition="contains any">2f40abbb4f78e77745f0e657a19903fc953cc664;478dc5a5f934c62a9246f7d1fc275868f568bc07;37b4496e650b3994312c838435013560b3ca8571;37b4496e650b3994312c838435013560b3ca8571;e8542c07b2af63ee7e72ce5d97d91036c5da56e2b091aa2afe737b224305d230;08c34c6ac9186b61d9f29a77ef5e618067e0bc9fe85cab1ad25dc6049c376949;5fc4b0076eac7aa7815302b0c3158076e3569086c4c6aa2f71cd258238440d14;bef59b9a3e00a14956e0cd4a1f3e7524448cbe5d3cc1295d95a15b83a3579c59;2c1d3d0a9c6f76726994b88589219cb8d9c39dd9924bc8d2d02bf41d955fe326;1a2ab4df156ccd685f795baee7df49f8e701f271d3e5676b507112e30ce03c42;758598370c3b84c6fbb452e3d7119f700f970ed566171e879d3cb41102154272;5c776a33568f4c16fee7140c249c0d2b1e0798a96c7a01bfd2d5684e58c9bb32;c96ed56bf7ee85a4398cc43a98b4db86d3da311c619f17c8540ae424ca6546e1;c96ed56bf7ee85a4398cc43a98b4db86d3da311c619f17c8540ae424ca6546e1;36dd195269979e01a29e37c488928497;7d9d29c1c03461608bcab930fef2f568;807d86da63f0db1fc746d1f0b05bc357;849a2b0dc80aeca3d175c139efe5221c;86A4CAC227078B9C95C560C8F0370BF0;98908ce6f80ecc48628c8d2bf5b2a50c;a4b42c2c95d1f2ff12171a01c86cd64f;4abe604916c04fe3dd8b9cb3d501d3f;eac3e3ece94bc84e922ec077efb15edd;128CECC59C91C0D0574BC1075FE7CB40;88777aacd5f16599547926a4c9202862;0f49621b06f2cdaac8850c6e9581a594;17a36ac3e31f3a18936552aff2c80249;322cb39bc049aa69136925137906d855;2010f38ef300be4349e7bc287e720b1ecec678cacbf0ea0556bcf765f6e073ec;cd4b9d0f2d1c0468750855f0ed352c1ed6d4f512d66e0e44ce308688235295b5;5b102bf4d997688268bab45336cead7cdf188eb0d6355764e53b4f62e1cdf30c;b017b9fc2484ce0a5629ff1fed15bca9f62f942eafbb74da6a40f40337187b04;6a251ed6a2c6a0a2be11f2a945ec68c814d27e2b6ef445f4b2c7a779620baa11;3d129263f6a48647f103a04446fb0c2f;37cd353621b0f4fc6981b50071c94f01;1b60021baedc3f9201bcdb40e9b87f62;71345b139166482acaa568ac8816c7bc;5E022694C0DBD1FBBC263D608E577949;304772c80b157a916c7041f2f15939fb;291ff87948e45914424cec9510c297da;b8fcd4a3902064907fb19e0da3ca7aed72a7e6d1f94d971d1ee7a4d3af6a800d;965884f19026913b2c57b8cd4a86455a61383de01dabb69c557f45bb848f6c26;4a069c1abe5aca148d5a8fdabc26751e;dc5733c013378fa418d13773f5bfe6f1;c579341f86f7e962719c7113943bb6e4;d326e629a90e78825645963b35e53a6a;5E022694C0DBD1FBBC263D608E577949;53841a0c6a3ff92976db08bfdf95e083;dc7e564809d6c2a2f3457c3c9b91f22b;5470f0644589685000154cb7d3f60280acb16e39ca961cce2c016078b303bc1b;FE2CA1BE3BDA2A757036A89E54CC02DB;FE2CA1BE3BDA2A757036A89E54CC02DB</Hashes>
+			</Rule>
+			<Hashes name="Attack=T1353,Technique=Post Compromise Tool Development,Tactic=Build Capabilities,Level=4,Alert=TajMahal APT Tool Detection,Risk=100" condition="contains any">22d142f11cf2a30ea4953e1fffb0fa7e;2317d65da4639f4246de200650a70753;27612cb03c89158225ca201721ea1aad;412956675fbc3f8c51f438c1abc100eb;daf2da52475fd8981b19ec3c321a983c;490a140093b5870a47edc29f33542fd2;51a7068640af42c3a7c1b94f1c11ab9d;533340c54bd25256873b3dca34d7f74e;684eca6b62d69ce899a3ec3bb04d0a5b;69a19abf5ba56ee07cdd3425b07cf8bf;6cfd131fef548fcd60fbcdb59317df8e;72dc98449b45a7f1ccdef27d51e31e91;7c733607a0932b1b9a9e27cd6ab55fe0;7d5265e814843b24fcb3787768129040;80c37e062aa4c94697f287352acf2e9d;815f1f8a7bc1e6f94cb5c416e381a110;a43d3b31575846fa4c3992b4143a06da;08e82dc7bae524884b7dc2134942aadb;7bcd736a2394fc49f3e27b3987cce640;57314359df11ffdf476f809671ec0275;b72737b464e50aa3664321e8e001ff32;ce8ce92fb6565181572dce00d69c24f8;5985087678414143d33ffc6e8863b887;84730a6e426fbd3cf6b821c59674c8a0;d5377dc1821c935302c065ad8432c0d2;d8f1356bebda9e77f480a6a60eab36bb;92f8e3f0f1f7cc49fad797a62a169acd;9003cfaac523e94d5479dc6a10575e60;df91b86189adb0a11c47ce2405878fa1;e17bd40f5b5005f4a0c61f9e79a9d8c2;c1e7850da5604e081b9647b58248d7e8;99828721ac1a0e32e4582c3f615d6e57;f559c87b4a14a4be1bd84df6553aaf56;b9c208ea8115232bfd9ec2c62f32d6b8;061089d8cb0ca58e660ce2e433a689b3;0e9afd3a870906ebf34a0b66d8b07435;9c115e9a81d25f9d88e7aaa4313d9a8f;520ee02668a1c7b7c262708e12b1ba6b;7bfba2c69bed6b160261bdbf2b826401;77a745b07d9c453650dd7f683b02b3ed;3a771efb7ba2cd0df247ab570e1408b2;0969b2b399a8d4cd2d751824d0d842b4;fc53f2cd780cd3a01a4299b8445f8511;4e39620afca6f60bb30e031ddc5a4330;bfe3f6a79cad5b9c642bb56f8037c43b;3dfebce4703f30eed713d795b90538b5;9793afcea43110610757bd3b800de517;36db24006e2b492cafb75f2663f241b2;21feb6aa15e02bb0cddbd544605aabad;21feb6aa15e02bb0cddbd544605aabad;649ef1dd4a5411d3afcf108d57ff87af;320b2f1d9551b5d1df4fb19bd9ab253a;3d75c72144d873b3c1c4977fbafe9184;b9cf4301b7b186a75e82a04e87b30fe4;b4e67706103c3b8ee148394ebee3f268;7bfbd72441e1f2ed48fbc0f33be00f24;cdb303f61a47720c7a8c5086e6b2a743;2a6f7ec77ab6bd4297e7b15ae06e2e61;8403a28e0bffa9cc085e7b662d0d5412;3ffd2915d285ad748202469d4a04e1f5;04078ef95a70a04e95bda06cc7bec3fa;235d427f94630575a4ea4bff180ecf5d;8035a8a143765551ca7db4bc5efb5dfd;cacaa3bf3b2801956318251db5e90f3c;1aadf739782afcae6d1c3e4d1f315cbd;c3e255888211d74cc6e3fb66b69bbffb;d9e9f22988d43d73d79db6ee178d70a4;16ab79fb2fd92db0b1f38bedb2f02ed8;8da15a97eaf69ff7ee184fc446f19cf1;ffc7305cb24c1955f9625e525d58aeee;c0e72eb4c9f897410c795c1b360090ef;9ad6fa6fdedb2df8055b3d30bd6f64f1;44619a88a6cff63523163c6a4cf375dd;a571660c9cf1696a2f4689b2007a12c7;81229c1e272218eeda14892fa8425883;0ac48cfa2ff8351365e99c1d26e082ad;afcdf79be1557326c854b6e20cb900a7</Hashes> <!-- https://securelist.com/project-tajmahal/90240/ -->
+			<Hashes name="Attack=T1353,Technique=Post Compromise Tool Development,Tactic=Build Capabilities,Level=3,Alert=Windows-Credential Editor Detection,Risk=70" condition="contains">a53a02b997935fd8eedcb5f7abab9b9f</Hashes> <!-- https://securelist.com/project-tajmahal/90240/ -->
+			<Hashes name="Attack=T1353,Technique=Post Compromise Tool Development,Tactic=Build Capabilities,Level=3,Alert=Windows-Credential Editor Detection,Risk=70" condition="contains">e96a73c7bf33a464c510ede582318bf2</Hashes> <!-- https://securelist.com/project-tajmahal/90240/ -->
+			<Image name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=3,Alert=Emotet Execution Detected,Risk=100" condition="contains">serialfunc.exe</Image>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Emotet Command Line detection" groupRelation="and">
+				<CommandLine condition="contains any">e PAA;en PAA;enc PAA;enco PAA;encode PAA;encoded PAA;encodedco PAA;encodedcom PAA;encodedcomm PAA;encodedcomma PAA;encodedcomman PAA;encodedcommand PAA;e IAA;en IAA;enc IAA;enco IAA;encode IAA;encoded IAA;encodedco IAA;encodedcom IAA;encodedcomm IAA;encodedcomma IAA;encodedcomman IAA;encodedcommand IAA;e JAB;en JAB;enc JAB;enco JAB;encode JAB;encoded JAB;encodedco JAB;encodedcom JAB;encodedcomm JAB;encodedcomma JAB;encodedcomman JAB;encodedcommand JAB;e cwBFAFQA;en cwBFAFQA;enc cwBFAFQA;enco cwBFAFQA;encode cwBFAFQA;encoded cwBFAFQA;encodedco cwBFAFQA;encodedcom cwBFAFQA;encodedcomm cwBFAFQA;encodedcomma cwBFAFQA;encodedcomman cwBFAFQA;encodedcommand cwBFAFQA;e SQBFAF;en SQBFAF;enc SQBFAF;enco SQBFAF;encode SQBFAF;encoded SQBFAF;encodedco SQBFAF;encodedcom SQBFAF;encodedcomm SQBFAF;encodedcomma SQBFAF;encodedcomman SQBFAF;encodedcommand SQBFAF;e UwBFAFQA;en UwBFAFQA;enc UwBFAFQA;enco UwBFAFQA;encode UwBFAFQA;encoded UwBFAFQA;encodedco UwBFAFQA;encodedcom UwBFAFQA;encodedcomm UwBFAFQA;encodedcomma UwBFAFQA;encodedcomman UwBFAFQA;encodedcommand UwBFAFQA;e IABpAE4AdgBPAEsAZQAt;en IABpAE4AdgBPAEsAZQAt;enc IABpAE4AdgBPAEsAZQAt;enco IABpAE4AdgBPAEsAZQAt;encode IABpAE4AdgBPAEsAZQAt;encoded IABpAE4AdgBPAEsAZQAt;encodedco IABpAE4AdgBPAEsAZQAt;encodedcom IABpAE4AdgBPAEsAZQAt;encodedcomm IABpAE4AdgBPAEsAZQAt;encodedcomma IABpAE4AdgBPAEsAZQAt;encodedcomman IABpAE4AdgBPAEsAZQAt;encodedcommand IABpAE4AdgBPAEsAZQAt;e SQBmACgAJAB;en SQBmACgAJAB;enc SQBmACgAJAB;enco SQBmACgAJAB;encode SQBmACgAJAB;encoded SQBmACgAJAB;encodedco SQBmACgAJAB;encodedcom SQBmACgAJAB;encodedcomm SQBmACgAJAB;encodedcomma SQBmACgAJAB;encodedcomman SQBmACgAJAB;encodedcommand SQBmACgAJAB;e J;en J;enc J;enco J;encode J;encoded J;encodedco J;encodedcom J;encodedcomm J;encodedcomma J;encodedcomman J;encodedcommand J;e SUVY;en SUVY;enc SUVY;enco SUVY;encode SUVY;encoded SUVY;encodedco SUVY;encodedcom SUVY;encodedcomm SUVY;encodedcomma SUVY;encodedcomman SUVY;encodedcommand SUVY;e aWV4;en aWV4;enc aWV4;enco aWV4;encode aWV4;encoded aWV4;encodedco aWV4;encodedcom aWV4;encodedcomm aWV4;encodedcomma aWV4;encodedcomman aWV4;encodedcommand aWV4;e dmFy;en dmFy;enc dmFy;enco dmFy;encode dmFy;encoded dmFy;encodedco dmFy;encodedcom dmFy;encodedcomm dmFy;encodedcomma dmFy;encodedcomman dmFy;encodedcommand dmFy;e dgBhA;en dgBhA;enc dgBhA;enco dgBhA;encode dgBhA;encoded dgBhA;encodedco dgBhA;encodedcom dgBhA;encodedcomm dgBhA;encodedcomma dgBhA;encodedcomman dgBhA;encodedcommand dgBhA;e R2V0;en R2V0;enc R2V0;enco R2V0;encode R2V0;encoded R2V0;encodedco R2V0;encodedcom R2V0;encodedcomm R2V0;encodedcomma R2V0;encodedcomman R2V0;encodedcommand R2V0;e IAAgAH;en IAAgAH;enc IAAgAH;enco IAAgAH;encode IAAgAH;encoded IAAgAH;encodedco IAAgAH;encodedcom IAAgAH;encodedcomm IAAgAH;encodedcomma IAAgAH;encodedcomman IAAgAH;encodedcommand IAAgAH;e TVq;en TVq;enc TVq;enco TVq;encode TVq;encoded TVq;encodedco TVq;encodedcom TVq;encodedcomm TVq;encodedcomma TVq;encodedcomman TVq;encodedcommand TVq;e aQBIA;en aQBIA;enc aQBIA;enco aQBIA;encode aQBIA;encoded aQBIA;encodedco aQBIA;encodedcom aQBIA;encodedcomm aQBIA;encodedcomma aQBIA;encodedcomman aQBIA;encodedcommand aQBIA;e UEs;en UEs;enc UEs;enco UEs;encode UEs;encoded UEs;encodedco UEs;encodedcom UEs;encodedcomm UEs;encodedcomma UEs;encodedcomman UEs;encodedcommand UEs;e H4s;en H4s;enc H4s;enco H4s;encode H4s;encoded H4s;encodedco H4s;encodedcom H4s;encodedcomm H4s;encodedcomma H4s;encodedcomman H4s;encodedcommand H4s;e dXNpbm;en dXNpbm;enc dXNpbm;enco dXNpbm;encode dXNpbm;encoded dXNpbm;encodedco dXNpbm;encodedcom dXNpbm;encodedcomm dXNpbm;encodedcomma dXNpbm;encodedcomman dXNpbm;encodedcommand dXNpbm;e cwBhA;en cwBhA;enc cwBhA;enco cwBhA;encode cwBhA;encoded cwBhA;encodedco cwBhA;encodedcom cwBhA;encodedcomm cwBhA;encodedcomma cwBhA;encodedcomman cwBhA;encodedcommand cwBhA;JABzA</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Emotet Command Line detection 2" groupRelation="and">
+				<CommandLine condition="contains all">FromBase64String</CommandLine>
+				<CommandLine condition="contains any">JAB;SUVY;aWV4;dmFy;dgBhA;R2V0;SQBFAF;TVq;aQBIA;UEs;H4s;dXNpbm;cwBhA</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Emotet Command Line detection 3" groupRelation="and">
+				<CommandLine condition="contains any">/v Word experienced;/v Excel experienced;-v Word experienced;-v Excel experienced</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Emotet Command Line detection 4" groupRelation="and">
+				<CommandLine condition="contains any">JABlAG4AdgA6AHUAcwBlAHIAcAByAG8AZgBpAGwAZQ;QAZQBuAHYAOgB1AHMAZQByAHAAcgBvAGYAaQBsAGUA;kAGUAbgB2ADoAdQBzAGUAcgBwAHIAbwBmAGkAbABlA;IgAoACcAKgAnACkAOwAkA;IAKAAnACoAJwApADsAJA;iACgAJwAqACcAKQA7ACQA</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Obfuscated Emotet Command Line detection" groupRelation="and">
+				<CommandLine condition="contains any">e^;^en^;^nc</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=3,Alert=Suspicious Obfuscation Character" groupRelation="and">
+				<CommandLine condition="contains">^</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=3,Alert=Suspicious Directory Traversal" groupRelation="and">
+				<CommandLine condition="contains any">..\;\..</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=3,Alert=Formbook detections" groupRelation="and">
+				<CommandLine condition="contains any">\cmd.exe /c del "C:\Users\*\AppData\Local\Temp\*.exe;\cmd.exe /c del "C:\Users\*\Desktop\*.exe;\cmd.exe -c del "C:\Users\*\AppData\Local\Temp\*.exe;\cmd.exe -c del "C:\Users\*\Desktop\*.exe</CommandLine>
+			</Rule>
+			<CommandLine name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=3,Alert=QBot Process Creation,Risk=100" condition="contains any">ping.exe -n 6 127.0.0.1 &#38;ping.exe /n 6 127.0.0.1 &#38; type</CommandLine>
+			<CommandLine name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=3,Alert=Powershell RAW ping,Risk=100" condition="contains">System.Net.Networkinformation.ping</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Windows Management Instrumentation-->
+			<Image name="Attack=T1158,Technique=Windows Management Instrumentation,Tactic=Execution,Level=0,Desc=Mofcomp execution or persistence,Risk=50" condition="image">mofcomp.exe</Image>
+
+			<!--MITRE ATT&CK TACTIC: Persistence-->
+			<!--MITRE ATT&CK TECHNIQUE: Account Manipulation-->
+			<Rule name="Attack=T1098,Technique=Account Manipulation,Tactic=Credential Access/Persistence,Level=3,Alert=Account Manipulation,Risk=80" groupRelation="and">
+				<Image condition="contains any">net.exe;net1.exe;net2.exe</Image>
+				<CommandLine condition="contains any">user;group;localgroup</CommandLine>
+				<CommandLine condition="contains any">remove;delete;active;del</CommandLine>
+				<ParentCommandLine condition="excludes">tvsu_tmp</ParentCommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: BITS Jobs-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Autostart Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Initialization Scripts-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Extensions-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Client Software Binary-->
+			<!--MITRE ATT&CK TECHNIQUE: Create Account-->
+			<Rule name="Attack=T1098,Technique=Create Account,Tactic=Persistence,Level=3,Alert=Account Created,Risk=80" groupRelation="and">
+				<Image condition="contains any">net.exe;net1.exe;net2.exe</Image>
+				<CommandLine condition="contains">user</CommandLine>
+				<CommandLine condition="contains any">add</CommandLine>
+				<ParentCommandLine condition="excludes">tvsu_tmp</ParentCommandLine>
+			</Rule>
+			<Image name="Attack=T1136,Technique=Create Account,Tactic=Persistence,Alert=Account Creation via command line,Alert=Account creation with dsmod,Risk=100" condition="image">dsmod.exe</Image>
+			<Image name="Attack=T1136,Technique=Create Account,Tactic=Persistence,Level=3,Alert=Account Creation via command line,Alert=Account creation with dsadd,Risk=100" condition="image">dsadd.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Create or Modify System Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Event Triggered Execution-->
+			<Rule name="Attack=T1183,Technique=Image File Execution Options Injection,Tactic=Defense Evasion/Execution,Level=0,Alert=SilentProcessExit Execution from werfault S-Flag,Risk=75" groupRelation="and">
+				<ParentImage condition="image">WerFault.exe</ParentImage>
+				<ParentCommandLine condition="contains any">-s;/s</ParentCommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: External Remote Services-->
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<!--MITRE ATT&CK TECHNIQUE: Implant Internal Image-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Office Application Startup-->
+			<!--MITRE ATT&CK TECHNIQUE: Pre-OS Boot-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<!--MITRE ATT&CK TECHNIQUE: Server Software Component-->
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+
+			<!--MITRE ATT&CK TACTIC: Privilege Escalation-->
+			<Rule name="Attack=S0154,Tactic=Cobalt Strike,Technique=Malware,Level=4,Alert=Cobalt Strike GetSystem escalation Detected" groupRelation="and">
+				<Image condition="image">cmd.exe</Image>
+				<CommandLine condition="contains all">echo;\pipe\;&gt;</CommandLine>
+			</Rule>
+			<Rule name="Attack=S0154,Tactic=Cobalt Strike,Technique=Malware,Level=4,Alert=Cobalt Strike PSexec dll copy detected" groupRelation="and">
+				<Image condition="image">cmd.exe</Image>
+				<CommandLine condition="contains all">/c;copy;dll;\\;admin$</CommandLine>
+			</Rule>
+			<Rule name="Attack=S0154,Tactic=Cobalt Strike,Technique=Malware,Level=4,Alert=Cobalt Strike Exec DLL Detected" groupRelation="and">
+				<Image condition="image">rundll32.exe</Image>
+				<CommandLine condition="contains all">,;StartW</CommandLine>
+			</Rule>
+			<Rule name="Attack=S0154,Tactic=Cobalt Strike,Technique=Malware,Level=4,Alert=Cobalt Strike Susp activity 1" groupRelation="and">
+				<Image condition="image">rundll32.exe</Image>
+				<CommandLine condition="contains all">,;update;appdata;temp;/i:</CommandLine>
+			</Rule>
+			<Rule name="Attack=S0154,Tactic=Cobalt Strike,Technique=Malware,Level=4,Alert=Cobalt Strike Susp activity 2" groupRelation="and">
+				<Image condition="image">rundll32.exe</Image>
+				<CommandLine condition="contains all">,;update;appdata;temp;-i:</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1548,Tactic=Defense Evasion,Technique=Abuse Elevation Control Mechanism,Level=3,Alert=CMSTPLUA UAC Bypass Child Processes" groupRelation="and">
+				<ParentImage condition="image">dllhost.exe</ParentImage>
+				<ParentCommandLine condition="contains any">{3E5FC7F9-9A51-4367-9063-A120244FBEC7};{3E000D72-A845-4CD9-BD83-80C07C3B881F};{D2E7041B-2927-42fb-8E9F-7CE93B6DC937};{02B49784-1CA2-436C-BC08-72FA3956507D};{BEF590BE-11A6-442A-A85B-656C1081E04C}</ParentCommandLine>
+			</Rule>
+			<Rule name="Attack=T1548,Tactic=Defense Evasion,Technique=Abuse Elevation Control Mechanism,Level=3,Alert=CMSTPLUA UAC Bypass" groupRelation="and">
+				<Image condition="image">dllhost.exe</Image>
+				<CommandLine condition="contains any">{3E5FC7F9-9A51-4367-9063-A120244FBEC7};{3E000D72-A845-4CD9-BD83-80C07C3B881F};{D2E7041B-2927-42fb-8E9F-7CE93B6DC937};{02B49784-1CA2-436C-BC08-72FA3956507D};{BEF590BE-11A6-442A-A85B-656C1081E04C}</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Abuse Elevation Control Mechanism-->
+			<Rule name="Attack=T1548,Technique=Abuse Elevation Control Mechanism,Tactic=Privilege Escalation,Level=3,Alert=Abused Debug priviledge by Arbitrary Parent Process,Risk=100" groupRelation="and">
+				<ParentImage condition="contains any">winlogon.exe;services.exe;lsass.exe;csrss.exe;wininit.exe;spoolsv.exe;searchindexer.exe</ParentImage>
+				<Image condition="contains any">powershell.exe;pwsh.exe;cmd.exe</Image>
+				<User condition="contains any">AUTHORI;AUTORI</User>
+				<CommandLine condition="excludes any">route ; ADD </CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Abuse Elevation Control Mechanism: Bypass User Account Control-->
+			<Rule name="Attack=T1088,Technique=UAC Bypass,Tactic=Defense Evasion/Privilege Escalation,Risk=20" groupRelation="and">
+				<ParentImage condition="image">eventvwr.exe</ParentImage>
+				<Image condition="is not">c:\windows\system32\mmc.exe</Image>
+			</Rule>
+			<ParentImage name="Attack=T1088,Technique=UAC Bypass,Tactic=Defense Evasion/Privilege Escalation" condition="image">fodhelper.exe</ParentImage>
+			<Image name="Attack=T1118,Technique=InstallUtil,Tactic=Execution,Level=0,Desc=InstallUtil" condition="image">InstallUtil.exe</Image>
+			<CommandLine name="Attack=T1088,Technique=Bypass User Account Control,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=UAC Bypass" condition="contains">Invoke-PsUaCme</CommandLine>
+			<CommandLine name="Attack=T1088,Technique=Bypass User Account Control,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=UAC Bypass" condition="contains">BypassUAC</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Powerup Command Line events" condition="contains">PowerUp</CommandLine>
+			<OriginalFileName name="Attack=T1548.002,Technique=Bypass User Account Control,Tactic=Defense Evasion" condition="is">computerdefaults.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1548.002,Technique=Bypass User Account Control,Tactic=Defense Evasion" condition="is">dism.exe</OriginalFileName>
+			<ParentImage name="Attack=T1548.002,Technique=Bypass User Account Control,Tactic=Defense Evasion" condition="is">fodhelper.exe</ParentImage>
+			<!--MITRE ATT&CK TECHNIQUE: Access Token Manipulation-->
+			<Rule name="Attack=T1088,Technique=Access Token Manipulation,Tactic=Privilege Escalation,Risk=90,Level=3,Alert=Priv Escalation to System" groupRelation="and">
+				<ParentUser condition="contains any">NT AUTHORITY\NETWORK SERVICE;NT AUTHORITY\LOCAL SERVICE;SERVICE LOCAL;ERVICE RÉSEAU;NETZWERKDIENST;LOKALER DIENST;NETZWERKDIENST;SERVICIO DE RED;ERVICIO LOC</ParentUser>
+				<User condition="contains any">NT AUTHORITY\SYSTEM;СИСТЕМА;NT-AUTORITÄT\SYSTEM;AUTORITE NT\SYSTEM</User>
+			</Rule>
+			<ParentCommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">c:\windows\system32\svchost.exe -k netsvcs -s Appinfo</ParentCommandLine> <!-- can be useful for tokens manip detection -->
+			<Image name="Attack=T1134,Technique=Access Token Manipulation,Tactic=NA,Level=2,Alert=Token Manipulation with runas.exe,Risk=70" condition="image">runas.exe</Image> 
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Autostart Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Initialization Scripts-->
+			<!--MITRE ATT&CK TECHNIQUE: Create or Modify System Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Policy Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Escape to Host-->
+			<!--MITRE ATT&CK TECHNIQUE: Event Triggered Execution-->
+			<Rule name="Attack=T1546.008,Technique=Accessibility Features,Tactic=Execution,Level=4,Alert=Utilman Lock Screen Bypass,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">Cmd.Exe</OriginalFileName>
+				<ParentImage condition="image">winlogon.exe</ParentImage>
+				<Image condition="image">utilman.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1546.008,Technique=Accessibility Features,Tactic=Execution,Level=4,Alert=sethc.exe Lock Screen Bypass,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">Cmd.Exe</OriginalFileName>
+				<ParentImage condition="image">winlogon.exe</ParentImage>
+				<Image condition="image">sethc.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1546.008,Technique=Accessibility Features,Tactic=Persistence/Privilege Escalation,Level=4,Alert=Utilman Priv Escalation" groupRelation="and">
+				<ParentImage condition="image">utilman.exe</ParentImage>
+				<Image condition="excludes any">C:\Windows\System32\ATBroker.exe;Magnify.exe;C:\Windows\System32\osk.exe</Image>
+			</Rule>
+			<ParentImage name="Attack=T1015,Technique=Accessibility Features,Tactic=Persistence Privilege Escalation,Level=0,Desc=SETHC Priv Escalation" condition="image">sethc.exe</ParentImage>
+			<ParentImage name="Attack=T1015,Technique=Accessibility Features,Tactic=Persistence/Privilege Escalation" condition="image">osk.exe</ParentImage>
+			<ParentImage name="Attack=T1015,Technique=Accessibility Features,Tactic=Persistence/Privilege Escalation" condition="image">Magnify.exe</ParentImage>
+			<ParentImage name="Attack=T1015,Technique=Accessibility Features,Tactic=Persistence/Privilege Escalation" condition="image">DisplaySwitch.exe</ParentImage>
+			<ParentImage name="Attack=T1015,Technique=Accessibility Features,Tactic=Persistence/Privilege Escalation" condition="image">Narrator.exe</ParentImage>
+			<ParentImage name="Attack=T1015,Technique=Accessibility Features,Tactic=Persistence/Privilege Escalation" condition="image">AtBroker.exe</ParentImage>
+			<!--MITRE ATT&CK TECHNIQUE: Event Triggered Execution: Application Shimming-->
+			<Image name="Attack=T1138,Technique=Application Shimming,Tactic=Persistence/Privilege Escalation,Level=3,Alert=Application Shimming" condition="image">sdbinst.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Privilege Escalation-->
+			<Rule name="Attack=T1068,Technique=Exploitation for Privilege Escalation,Tactic=Privilege Escalation,Level=3,Alert=Exploiting SetupComplete.cmd,CVE=CVE-2019-1378,Risk=70" groupRelation="and">
+				<CommandLine condition="contains any">cmd.exe /c C:\Windows\Setup\Scripts\SetupComplete.cmd;cmd.exe /c C:\Windows\Setup\Scripts\PartnerSetupComplete.cmd</CommandLine>
+				<Image condition="excludes">C:\Windows\Setup</Image>
+				<Image condition="excludes">C:\Windows\SysWOW64</Image>
+				<Image condition="excludes">C:\Windows\System32</Image>
+				<Image condition="excludes">C:\Windows\WinSxS</Image>
+			</Rule>
+			<Rule name="Attack=T1068,Technique=Exploitation for Privilege Escalation,Tactic=Privilege Escalation,Level=3,Alert=IE Exploitation CVE-2019-1388,Risk=70" groupRelation="and">
+				<ParentImage condition="image">consent.exe</ParentImage>
+				<CommandLine condition="contains">http</CommandLine>
+				<Image condition="image">iexplore.exe</Image>
+				<User condition="contains">SYSTEM</User>
+			</Rule>
+			<Rule name="Attack=T1546.008,Technique=Exploitation for Privilege Escalation,Tactic=Privilege Escalation,Level=0,Desc=Dwm Exploitation" groupRelation="and">
+				<ParentImage condition="image">dwm.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1546.008,Technique=Exploitation for Privilege Escalation,Tactic=Privilege Escalation,Level=4,Alert=7zip Priv Escalation Detection,CVE=CVE-2022-29072" groupRelation="and">
+				<Image condition="image">cmd.exe</Image>
+				<ParentImage condition="image">7zFM.exe</ParentImage>
+				<CommandLine condition="excludes any">;/c;-c</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1546.008,Technique=Exploitation for Privilege Escalation,Tactic=Privilege Escalation,Level=4,Alert=Possible InstallerFileTakeOver LPE,CVE=CVE-2021-41379" groupRelation="and">
+				<Image condition="image">cmd.exe</Image>
+				<ParentImage condition="image">elevation_service.exe</ParentImage>
+				<IntegrityLevel condition="contains">System</IntegrityLevel>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Injection-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+
+			<!--MITRE ATT&CK TACTIC: Defense Evasion-->
+			<Image condition="contains">unknown process</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\LocalState\rootfs\</Image>
+			<ParentImage name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\LocalState\rootfs\</ParentImage>			
+			<!--MITRE ATT&CK TECHNIQUE: Abuse Elevation Control Mechanism-->
+			<!--MITRE ATT&CK TECHNIQUE: Access Token Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: BITS Jobs-->
+			<!--MITRE ATT&CK TECHNIQUE: Build Image on Host-->
+			<!--MITRE ATT&CK TECHNIQUE: Debugger Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Deobfuscate/Decode Files or Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Deploy Container-->
+			<!--MITRE ATT&CK TECHNIQUE: Direct Volume Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Policy Modification-->
+			<Rule name="Attack=T1484.001,Technique=Group Policy Modification,Tactic=Defense Evasion,Level=3,Alert=Auditpol System Audit Policy Change - Should be set via group policy instead" groupRelation="and">
+				<OriginalFileName condition="contains">auditpol</OriginalFileName>
+				<CommandLine condition="contains any">/set;-set;/restore;-restore;/clear;-clear;/remove;-remove;/resourceSACL;-resourceSACL</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Execution Guardrails-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Defense Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: File and Directory Permissions Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Hide Artifacts-->
+			<Rule name="Attack=T1164.001,Technique=Hidden Files and Directories,Tactic=Defense Evasion,Level=3,Alert=Hidden/SuperHidden File or Folder created" groupRelation="and">
+				<CommandLine condition="contains any">+s;+h</CommandLine>
+				<Image condition="image">attrib.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1164.001,Technique=Hidden Files and Directories,Tactic=Defense Evasion,Level=3,Alert=Powershell Hidden File or Folder created" groupRelation="and">
+				<CommandLine condition="contains all">Hidden;Attributes</CommandLine>
+				<Image condition="image">powershell.exe</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<!--MITRE ATT&CK TECHNIQUE: Impair Defenses-->
+			<Rule name="Attack=T1562,Technique=Impair Defenses,Tactic=Defense Evasion,Level=3,Alert=Stealth Sysmon Change Detected,Risk=100" groupRelation="and">
+				<Product condition="is">Sysinternals Sysmon</Product>
+				<CommandLine condition="contains any">/u;/c;-u;-c</CommandLine>
+				<CurrentDirectory condition="excludes">C:\ProgramdData\sysmon\</CurrentDirectory>
+			</Rule>
+			<Rule name="Attack=T1562.001,Technique=Disabling Security Tools,Tactic=Defense Evasion,Level=4,Alert=Windows Defender tampering,Risk=50" groupRelation="and">
+				<Image condition="image">MpCmdRun.exe</Image>
+				<CommandLine condition="contains any">Add-MpPreference;RemoveDefinitions;DisableIOAVProtection</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Impair Defenses: Disable or Modify Tools:  Disable Windows Event Logging-->
+			<Rule name="Attack=T1562.002,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=SysmonEnte Detection,Level=4,Risk=100" groupRelation="and">
+				<Hashes condition="contains">IMPHASH=84B763C45C0E4A3E7CA5548C710DB4EE</Hashes>
+			</Rule>
+			<Rule name="Attack=T1562.002,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=SysmonQuiet Detection,Level=4,Risk=100" groupRelation="and">
+				<Hashes condition="contains">IMPHASH=19584675D94829987952432E018D5056</Hashes>
+			</Rule>
+			<Rule name="Attack=T1562.002,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=SharpEvtMute Detection,Level=4,Risk=100" groupRelation="and">
+				<Hashes condition="contains">IMPHASH=330768a4f172e10acb6287b87289d83b</Hashes>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Impair Defenses: Disable or Modify Tools-->
+			<Image condition="image" name="Technique=Disabling Security Tools,Tactic=Defense Evasion,Attack=T1089,Level=4,Alert=PSTools PSKill,Risk=8">PsKill.exe</Image>
+			<Rule name="Technique=Disabling Security Tools,Tactic=Defense Evasion,Attack=T1089,Risk=100,Level=4,Alert=Disabling of Windows Defender Features" groupRelation="and">
+				<CommandLine condition="contains any">Set-MpPreference;Add-MpPreference;Remove-MpPreference;MpCmdRun.exe</CommandLine>
+				<CommandLine condition="contains any">RemoveDefinitions;RemoveDynamicSignature;DisableIOAVProtection;DisableRealTimeMonitoring;DisableBehaviorMonitoring;DisableBlockAtFirstSeen;DisableIOAVProtection;DisablePrivacyMode;DisableScriptScanning;DisableRealtimeMonitoring;DisableScanningNetworkFiles;DisableScanningMappedNetworkDrivesForFullScan;DisableRestorePoint;DisableRemovableDriveScanning;SignatureDisableUpdateOnStartupWithoutEngine;DisableIntrusionPreventionSystem;DisableScanOnRealtimeEnable;DisableArchiveScanning;DisableIntrusionPreventionSystem;DisableScriptScanning;DisableOnAccessProtection;ExclusionExtension;ExclusionPath;ExclusionProcess;ThreatDefaultAction;TamperProtection</CommandLine>
+			</Rule>
+			<CommandLine name="Attack=T1629.003,Technique=Impair Defenses: Disable or Modify Tools,Tactic=Defense Evasion,Level=2,Alert=netsh ipv6 modification,Risk=40" condition="contains">interface ipv6 set</CommandLine>
+			<CommandLine name="Attack=T1629.003,Technique=Impair Defenses: Disable or Modify Tools,Tactic=Defense Evasion,Level=2,Alert=netsh ipv4 modification,Risk=40" condition="contains">interface ipv4 set</CommandLine>
+			<Image name="Attack=T1089,Technique=Disabling Security Tools,Tactic=Defense Evasion,Level=0,Desc=Command Line task kill 2,Risk=30" condition="image">taskkill.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Impair Defenses: Disable or Modify System Firewall-->
+			<CommandLine name="Attack=T1562.004,Technique=Disable or Modify System Firewall,Tactic=Defense Evasion,Level=3,Alert=netsh Firewall Rule Deletion,Risk=40" condition="contains">firewall delete</CommandLine> 
+			<CommandLine name="Attack=T1562.004,Technique=Disable or Modify System Firewall,Tactic=Defense Evasion,Level=2,Alert=netsh Firewall Rule Creation,Risk=40" condition="contains">firewall add</CommandLine> 
+			<CommandLine name="Attack=T1562.004,Technique=Disable or Modify System Firewall,Tactic=Defense Evasion,Level=4,Alert=netsh firewall disablement,Risk=40" condition="contains">firewall set opmode disable</CommandLine>
+			<CommandLine name="Attack=T1562.004,Technique=Disable or Modify System Firewall,Tactic=Defense Evasion,Level=4,Alert=Possible Arp Spoofing attacks" condition="contains">Core Networking - Router Solicitation</CommandLine>
+			<CommandLine name="Attack=T1562.004,Technique=Disable or Modify System Firewall,Tactic=Defense Evasion,Level=0,Desc=Windows Firewall Modifications,Risk=40" condition="contains">netsh advfirewall firewall</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Indicator Removal on Host-->
+			<Rule name="Attack=T1070.001,Technique=Clear Windows Event Logs,Tactic=Defense Evasion,Level=4,Alert=Eventlog Removal on Host,Risk=100" groupRelation="and">
+				<Image condition="image">wevtutil.exe</Image>
+				<CommandLine condition="contains"> cl </CommandLine>
+				<CommandLine condition="excludes">wevtutil im</CommandLine>
+				<CommandLine condition="excludes">wevtutil.exe im</CommandLine>
+				<CurrentDirectory condition="excludes">ClickToRun</CurrentDirectory>
+			</Rule>
+			<Rule name="Attack=T1562.006,Technique=Indicator Blocking,Tactic=Defense Evasion,Risk=50" groupRelation="and">
+				<OriginalFileName condition="is">fltMC.exe</OriginalFileName>
+				<CommandLine condition="contains any">detach;unload</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1070,Technique=Indicator Removal on Host,Tactic=Defense Evasion,Level=4,Alert=IIS Log disablement,Risk=80" groupRelation="and">
+				<OriginalFileName condition="is">appcmd.exe</OriginalFileName>
+				<CommandLine condition="contains all">DontLog;True</CommandLine>
+				<Image condition="excludes">iisetup.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1070,Technique=Impair Defenses: Indicator Removal on Host,Tactic=Defense Evasion,Level=3,Alert=Usagelog Env Tampering,Risk=70" groupRelation="or">
+				<CommandLine condition="contains all">set;NGenAssemblyUsageLog</CommandLine>
+				<CommandLine condition="contains all">New-ItemProperty;NGenAssemblyUsageLog</CommandLine>
+				<CommandLine condition="contains all">reg;add;dword;NGenAssemblyUsageLog</CommandLine>
+				<CommandLine condition="contains all">$env;NGenAssemblyUsageLog</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1070,Technique=Impair Defenses: Indicator Removal on Host,Tactic=Defense Evasion,Level=3,Alert=COMPlus_ETWEnabled Env Tampering,Risk=70" groupRelation="or">
+				<CommandLine condition="contains all">set;COMPlus_ETWEnabled</CommandLine>
+				<CommandLine condition="contains all">New-ItemProperty;COMPlus_ETWEnabled</CommandLine>
+				<CommandLine condition="contains all">reg;add;dword;COMPlus_ETWEnabled</CommandLine>
+				<CommandLine condition="contains all">$env;COMPlus_ETWEnabled</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Indirect Command Execution-->
+			<Rule name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=0,Desc=Windows Subsystem For Linux exec,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains any">bash.exe;wsl.exe;ubuntu.exe;kali.exe</OriginalFileName>
+				<CommandLine condition="contains any">-e;/e;-u root;--exec bash;dev/tcp</CommandLine>
+			</Rule>
+			<Image name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=0,Desc=Windows Subsystem For Linux,Risk=20" condition="image">wsl.exe</Image>
+			<ParentImage name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=0,Desc=Windows Subsystem For Linux,Risk=20" condition="image">wsl.exe</ParentImage>
+			<Image name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=0,Desc=Windows Subsystem For Linux,Risk=20" condition="image">wslhost.exe</Image>
+			<ParentImage name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=0,Desc=Windows Subsystem For Linux,Risk=20" condition="image">wslhost.exe</ParentImage>
+			<Image name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=0,Desc=Ubuntu Windows Subsystem For Linux,Risk=20" condition="image">ubuntu.exe</Image>
+			<ParentImage name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=0,Desc=Ubuntu Windows Subsystem For Linux,Risk=20" condition="image">ubuntu.exe</ParentImage>
+			<Image name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=4,Alert=Kali Windows Subsystem For Linux,Risk=100" condition="image">kali.exe</Image>
+			<ParentImage name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=4,Alert=Kali Windows Subsystem For Linux,Risk=100" condition="image">kali.exe</ParentImage>
+
+			<Image name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=2,Alert=Indirect Command Execution" condition="image">pcalua.exe</Image>
+			<ParentImage name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=2,Alert=Indirect Command Execution" condition="image">pcalua.exe</ParentImage>
+			<Image name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=0,Desc=Bash on Windows Execution,Risk=30" condition="image">bash.exe</Image>
+			<ParentImage name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=0,Desc=Bash on windows execution,Risk=30" condition="image">bash.exe</ParentImage>
+			<Image name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=0,Desc=Indirect Command Execution with forfiles" condition="image">forfiles.exe</Image>
+			<ParentImage name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=0,Desc=Indirect command execution forfiles child process" condition="image">forfiles.exe</ParentImage>
+			<Image name="Attack=T1059,Technique=Command-Line Interface,Tactic=Execution" condition="end with">.com</Image>
+			<CommandLine name="Attack=T1202,Technique=Indirect Command Execution,Tactic=Execution,Level=2,Alert=Scriptrunner exec" condition="contains">-appvscript</CommandLine>
+
+			<!--MITRE ATT&CK TECHNIQUE: Masquerading-->
+			<Rule name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=3,Alert=suspicious execution path,Risk=30" groupRelation="and">
+				<Image condition="contains any">C:\Users\NetworkService\;C:\Users\NetworkService\;HarddiskVolumeShadowCopy;C:\Users\Default\;C:\Users\Public;C:\Users\Guest\;\administrateur\;C:\Windows\Media\;C:\Windows\addins\;tsclient\;\htdocs\;\config\systemprofile\;C:\PerfLogs\;c:\windows\ServiceProfiles\;C:\Intel\Logs\;C:\Windows\repair\;C:\Windows\Help\;$Recycle;C:\Windows\Debug\;C:\Windows\Security\;C:\Windows\Fonts\;\wwwroot\;\Contacts;C:\Windows\vss\</Image>
+			</Rule>		
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Cloud Compute Infrastructure-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Registry-->
+			<CommandLine name="Attack=T1112,Technique=Modify Registry,Tactic=Defense Evasion,Level=3,Alert=Registry Class changes with reg.exe,Risk=40" condition="contains">reg add hkcu\software\classes\</CommandLine>
+			<CommandLine name="Attack=T1112,Technique=Modify Registry,Tactic=Defense Evasion,Level=3,Alert=Registry Class changes with reg.exe,Risk=40" condition="contains">reg.exe add hkcu\software\classes\</CommandLine> 
+			<ParentCommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\WINDOWS\system32\svchost.exe -k localService -s RemoteRegistry</ParentCommandLine>
+			<Rule name="Attack=T1112,Technique=Modify Registry,Tactic=Defense Evasion,Level=0,Desc=Alternate Data Streams with Regedit" groupRelation="and">
+				<OriginalFileName condition="is">regedit.exe</OriginalFileName>
+				<CommandLine condition="contains">:</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1112,Technique=Modify Registry,Tactic=Defense Evasion,Level=0,Desc=REG Registry Deletions" groupRelation="and">
+				<Image condition="image">reg.exe</Image>
+				<CommandLine condition="contains">delete </CommandLine>
+			</Rule>
+			<Rule name="Attack=T1112,Technique=Modify Registry,Tactic=Defense Evasion,Level=0,Desc=Regedit Registry Deletions" groupRelation="and">
+				<Image condition="image">regedit.exe</Image>
+				<CommandLine condition="contains any">/d;-d</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1112,Technique=Modify Registry,Tactic=Defense Evasion,Level=0,Desc=Powershell Registry Deletions" groupRelation="and">
+				<CommandLine condition="contains any">HKCU:;HKLM</CommandLine>
+				<CommandLine condition="contains">remove-item</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1112,Technique=Modify Registry,Tactic=Defense Evasion,Level=0,Desc=Powershell Registry Modifications" groupRelation="and">
+				<CommandLine condition="contains any">HKCU:;HKLM</CommandLine>
+				<CommandLine condition="contains">set-item;new-item</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Modify System Image-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Boundary Bridging-->
+			<!--MITRE ATT&CK TECHNIQUE: Obfuscated Files or Information-->
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=3,Alert=Suspicious Code Page Switch,Risk=50" groupRelation="and">
+				<Image condition="image">chcp.exe</Image>
+				<CommandLine condition="contains">936</CommandLine>
+				<CommandLine condition="contains">1256</CommandLine>
+				<CommandLine condition="contains">864</CommandLine>
+				<CommandLine condition="contains">1258</CommandLine>
+				<CommandLine condition="contains">855</CommandLine>
+				<CommandLine condition="contains">866</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Powershell Encoded Command Detected,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">powershell.exe</OriginalFileName>
+				<CommandLine condition="contains any">-e ;-en;-enc;-enco;-encod;-encode;-encoded;-encodedc;-encodedco;-encodedcom;-encodedcomm;-encodedcomma;-encodedcomman;-encodedcommand;/e ;/en;/enc;/enco;/encod;/encode;/encoded;/encodedc;/encodedco;/encodedcom;/encodedcomm;/encodedcomma;/encodedcomman;/encodedcommand</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Powershell Hidden Command,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">powershell.exe</OriginalFileName>
+				<CommandLine condition="contains any">-w h;-wi h;-win h;-wind h;-windo h;-window h;-windows h;-windowst h;-windowsty h;-windowstyl h;-windowstyle h;/w h;/wi h;/win h;/wind h;/windo h;/window h;/windows h;/windowst h;/windowsty h;/windowstyl h;/windowstyle h</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Powershell Execution Policy Bypass,Risk=75" groupRelation="and">
+				<OriginalFileName condition="contains">powershell.exe</OriginalFileName>
+				<CommandLine condition="contains any">-ex;/ex</CommandLine>
+				<CommandLine condition="contains">bypass</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=3,Alert=Powershell non-interactive Command" groupRelation="and">
+				<OriginalFileName condition="contains">powershell.exe</OriginalFileName>
+				<CommandLine condition="contains any">-noni;/noni</CommandLine>
+				<CommandLine condition="excludes">Import-Module FileServerResourceManager</CommandLine>
+				<CurrentDirectory condition="excludes">C:\Program Files\LogicMonitor</CurrentDirectory>
+			</Rule>
+			<Rule name="Attack=T1027,Tactic=Defense Evasion,Technique=Obfuscated Files or Information,Level=4,Alert=Powershell Obfuscation Command,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">powershell.exe</OriginalFileName>
+				<CommandLine condition="contains any">hextobin;iex;io.filestream;system.text;base64;system.io;io.file;IMAGE_SUBSYSTEM_WINDOWS_GUI;IMAGE_NT_OPTIONAL_HDR32;IMAGE_NT_OPTIONAL_HDR64;DllCharacteristicsType;GetDelegateForFunctionPointer;WriteProcessMemory;ReadProcessMemory;ImpersonateSelf;AdjustTokenPrivileges;NtCreateThreadEx;CreateRemoteThread;io.seek;iwr;-bxor;invoke-expression;remove.to.string;shellcode;System.Net.WebClient;System.Net.WebRequest;System.Net.SecurityProtocolType;unicode;-useb;msxml2.serverxmlhttp;wscript.shell;-comobject;frombase64;io.compression;system.convert;io.streamreader;io.memorystream;compression.gzipstream;text.encoding;executioncontext;text.enc;convertto-securestring;runtime.interop;verbosepreference;[[string]]::join</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Powershell Encoded Offsets,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">powershell.exe</OriginalFileName>
+				<CommandLine condition="contains any">SUVYI;aWV4I;SQBFAFgA;aQBlA;TW96aWxsYS;1vemlsbGEv;Nb3ppbGxhL;TQBvAHoAaQBsAGwAYQAv;0AbwB6AGkAbABsAGEAL;BNAG8AegBpAGwAbABhAC;UwB0AGE</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1001,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Obfuscated Suspicious or Malicious Commands,Risk=70" groupRelation="and">
+				<CommandLine condition="contains any">C^om^S^pEc;^c^o^m^S^p^E^c^;Wscript.Shell;-ComObject;MsXml2.ServerXmlHttp;Remove.ToString;System.Convert;-UseB;[Byte[];^h^t^t^p;h"t"t"p</CommandLine>
+			</Rule>
+			<CommandLine name="Attack=T1001,Technique=Obfuscated Files or Information with IwAjACMAd,Tactic=Defense Evasion,Level=4,Alert=Common Base 64 encoded cmds" condition="contains any">IwAjACMAd;IyM=;SUVYI;aWV4I;SQBFAFgA;aQBlAHgA;TW96aWxsYS;1vemlsbGEv;Nb3ppbGxhL;TQBvAHoAaQBsAGwAYQAv;0AbwB6AGkAbABsAGEAL;BNAG8AegBpAGwAbABhAC</CommandLine>
+			<CommandLine name="Attack=T1001,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Alert=Obfuscated Hidden Powershell,Risk=70" condition="contains any">WindowStyle Hidden function;WindowStyle Hidden;windowstyle h;windowstyl h;windowsty h;windowst h;windows h;window h;windo h;wind h;win h;wi h;-w h;/w h;win hi;win hid;win hidd;win hidde;win hidden</CommandLine>
+			<CommandLine name="Attack=T1001,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=3,Alert=Command Line Obfuscation,Risk=75" condition="contains">^</CommandLine>
+			<CommandLine name="Attack=T1001,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=0,Desc=Type CON Command Line Redirection" condition="contains">TYPE CON ></CommandLine>
+			<CommandLine name="Attack=T1001,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=0,Desc=Copy CON Command Line Redirection" condition="contains">copy CON ></CommandLine>
+			<CommandLine name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Common Obfuscated Commands,Risk=100" condition="contains any">FromBase64String;action=create keyvalue=;VerbosePreference.ToString;SecureString;CSharpCodeProvider;runtime.interopservices.marshal;system.globalization.numberstyles;system.reflection.assembly;hextobin;VerbosePreference.ToString;system.text.encoding;io.filestream;io.filestream;io.seekorigin;text.encoding;unicode.getstring;FromBase64;[Convert]::;System.IO.File]::ReadAllText;|iex</CommandLine>
+			<Rule name="Attack=T1105,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=CertUtil Decode,Risk=80" groupRelation="and">
+				<OriginalFileName condition="contains">certutil</OriginalFileName>
+				<CommandLine condition="contains any">decode;encode</CommandLine>
+			</Rule>
+			<!--FIX MITRE Mapping-->
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=Ping in Hexadecimal,Risk=60" groupRelation="and">
+				<Image name="Attack=T1027,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Ping in Hexadecimal" condition="image">ping.exe</Image>
+				<CommandLine condition="contains">0x</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Obfuscated Files or Information: Compile After Delivery-->
+			<Rule name="Level=4,Alert=CSC Suspicious Location,Risk=60" groupRelation="and">
+				<Image condition="image">csc.exe</Image>
+				<CommandLine condition="contains any">\AppData\;\Windows\Temp\</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1027.004,Technique=Compile After Delivery,Tactic=Defense Evasion,Level=3,Alert=Suspicious Parent of Csc.exe,Risk=80" groupRelation="and">
+				<Image condition="image">csc.exe</Image>
+				<ParentImage condition="image">wscript.exe</ParentImage>
+				<ParentImage condition="image">cscript.exe</ParentImage>
+				<ParentImage condition="image">mshta.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1027.004,Technique=Compile After Delivery,Tactic=Defense Evasion,Level=3,Alert=MOFComp compilation of .Mof File,Risk=80" groupRelation="and">
+				<Image condition="image">mofcomp.exe</Image>
+				<CommandLine condition="contains">.mof</CommandLine>
+				<CurrentDirectory condition="excludes">C:\WINDOWS\Installer\MSI</CurrentDirectory>
+				<ParentImage condition="excludes">MsMpEng.exe</ParentImage>
+				<ParentImage condition="excludes">aspnet_regiis.exe</ParentImage>
+				<ParentImage condition="excludes">msiexec.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1027.004,Technique=Compile After Delivery,Tactic=Defense Evasion,Level=3,Alert=CSC Compilation,Risk=80" groupRelation="and">
+				<ParentImage condition="is">csc.exe</ParentImage>
+				<CommandLine condition="contains any">out:;target:library</CommandLine>
+			</Rule>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Microsoft.Workflow.Compiler.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Plist File Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Pre-OS Boot-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Injection-->
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of Autochk,Risk=30" groupRelation="and">
+				<Image condition="image">autochk.exe</Image>
+				<ParentImage condition="excludes any">\smss.exe;\fontdrvhost.exe;\dwm.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of SMSS,Risk=30" groupRelation="and">
+				<Image condition="contains any">\consent.exe;\Runtimebroker.exe;\TiWorker.exe</Image>
+				<ParentImage condition="excludes">\svchost.exe</ParentImage>
+				<ParentImage condition="is not">-</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of consent/runtimebroke/tiworker,Risk=30" groupRelation="and">
+				<Image condition="contains any">\consent.exe;\Runtimebroker.exe;\TiWorker.exe</Image>
+				<ParentImage condition="excludes any">svchost.exe</ParentImage>
+				<ParentImage condition="is not">-</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of searchindexer,Risk=30" groupRelation="and">
+				<Image condition="image">SearchProtocolHost.exe</Image>
+				<ParentImage condition="excludes any">\SearchIndexer.exe;\dllhost.exe</ParentImage>
+				<ParentImage condition="is not">-</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of dllhost,Risk=30" groupRelation="and">
+				<Image condition="image">dllhost.exe</Image>
+				<ParentImage condition="excludes any">\services.exe;\svchost.exe</ParentImage>
+				<ParentImage condition="is not">-</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of smss,Risk=30" groupRelation="and">
+				<Image condition="image">smss.exe</Image>
+				<ParentImage condition="excludes">\smss.exe</ParentImage>
+				<ParentImage condition="is not">System</ParentImage>
+				<ParentImage condition="is not">-</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of csrss,Risk=30" groupRelation="and">
+				<Image condition="image">csrss.exe</Image>
+				<ParentImage condition="is not">-</ParentImage>
+				<ParentImage condition="excludes any">\smss.exe;svchost.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of wininit,Risk=30" groupRelation="and">
+				<Image condition="image">wininit.exe</Image>
+				<ParentImage condition="is not">-</ParentImage>
+				<ParentImage condition="excludes">\smss.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of winlogon,Risk=30" groupRelation="and">
+				<Image condition="image">winlogon.exe</Image>
+				<ParentImage condition="excludes">\smss.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of lsass/LsaIso,Risk=30" groupRelation="and">
+				<Image condition="contains any">\lsass.exe;LsaIso.exe</Image>
+				<ParentImage condition="excludes">\wininit.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of LogonUI,Risk=30" groupRelation="and">
+				<Image condition="image">LogonUI.exe</Image>
+				<ParentImage condition="excludes any">\wininit.exe;\winlogon.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of services,Risk=30" groupRelation="and">
+				<Image condition="image">services.exe</Image>
+				<ParentImage condition="excludes">\wininit.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of svchost,Risk=30" groupRelation="and">
+				<Image condition="image">svchost.exe</Image>
+				<ParentImage condition="is not">-</ParentImage>
+				<ParentImage condition="excludes any">\MsMpEng.exe;\services.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of spoolsv,Risk=30" groupRelation="and">
+				<Image condition="image">spoolsv.exe</Image>
+				<ParentImage condition="excludes">\services.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of taskhost,Risk=30" groupRelation="and">
+				<Image condition="image">taskhost.exe</Image>
+				<ParentImage condition="excludes any">\services.exe;\svchost.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of userinit,Risk=30" groupRelation="and">
+				<Image condition="image">userinit.exe</Image>
+				<ParentImage condition="excludes any">\dwm.exe;\winlogon.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Parent process of wmiprvse/wsmprovhost/winrshost,Risk=30" groupRelation="and">
+				<Image condition="contains any">\wmiprvse.exe;\wsmprovhost.exe;\winrshost.exe</Image>
+				<ParentImage condition="is not">-</ParentImage>
+				<ParentImage condition="excludes any">\svchost.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Child process of SearchProtocolHost/taskhost/csrss,Risk=30" groupRelation="and">
+				<ParentImage condition="contains any">\SearchProtocolHost.exe;\taskhost.exe;\csrss.exe</ParentImage>
+				<Image condition="excludes any">\werfault.exe;\wermgr.exe;\WerFaultSecure.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Child process of SearchProtocolHost/taskhost/csrss,Risk=30" groupRelation="and">
+				<ParentImage condition="image">autochk.exe</ParentImage>
+				<Image condition="excludes any">\chkdsk.exe;\doskey.exe;\WerFault.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Child process of smss,Risk=30" groupRelation="and">
+				<ParentImage condition="image">smss.exe</ParentImage>
+				<Image condition="excludes any">\autochk.exe;\smss.exe;\csrss.exe;\wininit.exe;\winlogon.exe;\setupcl.exe;\WerFault.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Child process of wermgr,Risk=30" groupRelation="and">
+				<ParentImage condition="image">wermgr.exe</ParentImage>
+				<Image condition="excludes any">\WerFaultSecure.exe;\wermgr.exe;\WerFault.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Privilege Escalation,Level=3,Alert=Suspicious Child process of conhost,Risk=30" groupRelation="and">
+				<ParentImage condition="image">conhost.exe</ParentImage>
+				<Image condition="excludes any">\mscorsvw.exe;\wermgr.exe;\WerFault.exe;\WerFaultSecure.exe</Image>
+			</Rule>
+			<CommandLine name="Attack=T1055,Technique=Powershell Injection Persistence Bypass - Execution, Lateral Movement,Tactic=Defense Evasion,Level=4,Alert=Powershell Injection persistence bypass,Risk=50" condition="contains">System.Management.Automation</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Reflective Code Loading-->
+			<!--MITRE ATT&CK TECHNIQUE: Rogue Domain Controller-->
+			<!--MITRE ATT&CK TECHNIQUE: Rootkit-->
+			<!--MITRE ATT&CK TECHNIQUE: Subvert Trust Controls-->
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<OriginalFileName name="Attack=T1218,Technique=Signed Binary Proxy Execution,Tactic=Execution,Risk=50" condition="is">InstallUtil.exe</OriginalFileName>
+				<CommandLine condition="contains all">/logfile=;/LogToConsole=false;/U</CommandLine>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<OriginalFileName name="Attack=T1218,Technique=Signed Binary Proxy Execution,Tactic=Execution,Risk=50" condition="is">InstallUtil.exe</OriginalFileName>
+				<CommandLine condition="contains all">-logfile=;-LogToConsole=false;-U</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.013,Technique=Mavinject,Tactic=Execution,Level=3,Alert=Mavinject Detected,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains any">Mavinject.exe;mavinject64.exe</OriginalFileName>
+				<CommandLine condition="contains">INJECTRUNNING</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.003,Technique=CMSTP,Tactic=Execution,Level=3,Alert=CMSTP UAC Bypass Detected 1,Risk=100" groupRelation="and">
+				<OriginalFileName condition="is">CMSTP.exe</OriginalFileName>
+				<CommandLine condition="contains all">/ni;/s</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.003,Technique=CMSTP,Tactic=Execution,Level=3,Alert=CMSTP UAC Bypass Detected 2,Risk=100" groupRelation="and">
+				<OriginalFileName condition="is">CMSTP.exe</OriginalFileName>
+				<CommandLine condition="contains all">/ns;/s</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.003,Technique=CMSTP,Tactic=Execution,Level=3,Alert=CMSTP UAC Bypass Detected 3,Risk=100" groupRelation="and">
+				<OriginalFileName condition="is">CMSTP.exe</OriginalFileName>
+				<CommandLine condition="contains all">-ni;-s</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.003,Technique=CMSTP,Tactic=Execution,Level=3,Alert=CMSTP UAC Bypass Detected 4,Risk=100" groupRelation="and">
+				<OriginalFileName condition="is">CMSTP.exe</OriginalFileName>
+				<CommandLine condition="contains all">-ns;-s</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.002,Technique=Control Panel,Tactic=Execution,Level=3,Alert=Control_Rundll Detected,Risk=50" groupRelation="and">
+				<CommandLine condition="contains all">rundll32.exe;shell32.dll;_RunDLL</CommandLine>
+				<Image condition="is not">C:\Windows\ImmersiveControlPanel\SystemSettings.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1218.008,Technique=Signed Binary Proxy Execution,Tactic=Execution,Level=3,Alert=Odbcconf Signed Binary Proxy Execution,Risk=50" groupRelation="and">
+				<Image condition="image">odbcconf.exe</Image>
+				<CommandLine condition="contains any">/S /A {REGSVR;-S -A {REGSVR</CommandLine>
+			</Rule>
+			<CommandLine name="Attack=T1218,Technique=Signed Script Proxy Execution,Tactic=Execution,Level=3,Alert=Script:http Detected,Risk=75" condition="contains">script:http</CommandLine>
+			<CommandLine name="Attack=T1218,Technique=Signed Script Proxy Execution,Tactic=Execution,Level=3,Alert=Register-cimprovider exec,Risk=100" condition="contains">Register-cimprovider</CommandLine>
+			<CommandLine name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="contains">Scriptrunner.exe -appvscript</CommandLine>
+			<CommandLine name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="contains">bginfo</CommandLine>
+			<CommandLine name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="contains">cbd</CommandLine>
+			<CommandLine name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution,Level=3,Alert=runscripthelper LOLBAS,Risk=40" condition="contains">runscripthelper.exe surfacecheck</CommandLine>
+			<CommandLine name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution,Level=3,Alert=xwizard LOLBAS,Risk=40" condition="contains">xwizard RunWizard</CommandLine>
+			<CommandLine name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution,Level=3,Alert=PresentationHost exec,Risk=100" condition="contains">PresentationHost</CommandLine>
+			<CommandLine name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution,Level=3,Alert=VBoxDrvInst.exe exec,Risk=100" condition="contains">driver executeinf</CommandLine>
+			<CommandLine name="Attack=T1218.002,Technique=Control Panel Items,Tactic=Execution,Level=3,Alert=Control Panel Execution,Risk=75" condition="contains any">control.exe /name;control.exe -name</CommandLine>
+			<CommandLine name="Attack=T1218.002,Technique=Control Panel Items,Tactic=Execution,Level=3,Alert=Control Panel Execution,Risk=75" condition="contains">Control_RunDLL</CommandLine>
+			<Image name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="image">SyncAppvPublishingServer.exe</Image>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="contains">Scriptrunner.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">ATBroker.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">Appvlp.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">InfDefaultInstall.EXE</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">PresentationHost.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">RegisterCimProvider2.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">RegisterCimProvider.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">ScriptRunner.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">csi.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">extexport.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">msconfig.EXE</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">rasdlui.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">tttracer.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">verclsid.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">wab.exe</OriginalFileName>
+			<OriginalFileName name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution,Level=3,Alert=Register-cimprovider.exe,Risk=100" condition="contains">Register-cimprovider.exe</OriginalFileName>
+			<ParentCommandLine name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="contains">csi.exe</ParentCommandLine>
+			<ParentCommandLine name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="contains">devtoolslauncher.exe LaunchForDeploy</ParentCommandLine>
+			<ParentCommandLine name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">bginfo</ParentCommandLine>
+			<ParentImage name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">devtoolslauncher.exe</ParentImage>
+			<ParentImage name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">wab.exe</ParentImage>
+			<ParentImage name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Execution" condition="is">wsreset.exe</ParentImage>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: CMSTP-->
+			<CommandLine name="Attack=T1218.003,Technique=System Binary Proxy Execution,Tactic=Defense Evasion" condition="contains any">cmstp.exe /ni /s;cmstp.exe -ni -s</CommandLine>
+			<CommandLine name="Attack=T1218.003,Technique=System Binary Proxy Execution,Tactic=Defense Evasion,Level=0,Desc=cmstp" condition="contains any">cmstp /ni /s;cmstp -ni -s</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Mavinject-->
+			<Image name="Attack=T1218,Technique=Mavinject,Tactic=Defense Evasion,Level=3,Alert=Mavinject Process Injection" condition="image">Mavinject.exe</Image>
+			<CommandLine name="Attack=T1218,Technique=Mavinject,Tactic=Defense Evasion,Level=3,Alert=Mavinject Process Injection" condition="contains">INJECTRUNNING</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Regsvr32-->
+			<Rule name="Attack=T1117,Technique=Regsvr32,Tactic=Execution,Level=3,Alert=Potential rundll32.exe DllRegisterServer execution,Risk=70" groupRelation="and">
+				<Image condition="image">rundll32.exe</Image>
+				<CommandLine condition="contains">DllRegisterServer</CommandLine>
+				<CommandLine condition="excludes any">xapauthenticodesip.dll</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1117,Technique=Regsvr32,Tactic=Execution,Level=3,Alert=Suspicious Regsvr32 loading in Appdata temp" groupRelation="and">
+				<Image condition="image">regsvr32.exe</Image> 
+				<CommandLine condition="contains all">C:\Users;Appdata;Temp</CommandLine> 
+			</Rule>
+			<Rule name="Attack=T1117,Technique=Regsvr32,Tactic=Defense Evasion/Execution,Level=4,Alert=Suspicious Regsvr32 loading in Public User folder" groupRelation="and">
+				<Image condition="image">regsvr32.exe</Image> 
+				<CommandLine condition="contains all">C:\Users;Public</CommandLine> 
+			</Rule>
+			<Description name="Attack=T1117,Technique=Regsvr32,Tactic=Execution" condition="contains">Microsoft(C) Register Server</Description>
+			<Image name="Attack=T1218,Technique=Signed Binary Proxy Execution,Tactic=Execution,Level=0,Desc=SyncAppvPublishingServer Applocker Bypass" condition="image">SyncAppvPublishingServer.exe</Image>
+			<Image name="Attack=T1218,Technique=Signed Binary Proxy Execution,Tactic=Execution,Level=0,Desc=control panel execution" condition="image">control.exe</Image>
+			<Image name="Attack=T1218,Technique=Signed Binary Proxy Execution,Tactic=Execution,Level=0,Desc=rasautou execution" condition="image">rasautou.exe</Image>
+			<CommandLine name="Attack=T1196,Technique=Control Panel Items,Tactic=Execution,Level=4,Alert=Control Panel Execution" condition="contains any">control.exe /name;control.exe -name</CommandLine>
+			<CommandLine name="Attack=T1196,Technique=Control Panel Items,Tactic=Execution,Level=4,Alert=Control Panel Execution" condition="contains">Control_RunDLL</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: MsiExec-->
+			<Rule name="Attack=T1218,Technique=Signed Binary Proxy Execution,Tactic=Execution,Level=0,Desc=Msiexec.exe DllRegisterServer execution,Risk=70" groupRelation="and">
+				<Image condition="image">msiexec.exe</Image>
+				<CommandLine condition="contains any">/y;-y</CommandLine>
+				<CommandLine condition="excludes">C:\Windows\SysWOW64\DartSock.dll</CommandLine>
+				<CommandLine condition="excludes">C:\Windows\SysWOW64\ImageViewer2.OCX</CommandLine>
+				<CommandLine condition="excludes">C:\Windows\SysWOW64\SysTray.ocx</CommandLine>
+				<CommandLine condition="excludes">C:\Windows\SysWOW64\tdbg6.ocx</CommandLine>
+				<CommandLine condition="excludes">C:\Windows\SysWOW64\tdbg7.ocx</CommandLine>
+				<CommandLine condition="excludes">C:\Windows\SysWOW64\tdbg7.ocx</CommandLine>
+				<CommandLine condition="excludes">C:\Windows\SysWOW64\todg7.ocx</CommandLine>
+				<CommandLine condition="excludes">C:\Windows\SysWOW64\todgub7.dll</CommandLine>
+				<CommandLine condition="excludes">C:\Windows\SysWOW64\xarraydb.ocx</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218,Technique=Signed Binary Proxy Execution,Tactic=Defense Evasion,Level=4,Alert=MSIExec Signed Binary Proxy Execution,Risk=70" groupRelation="and">
+				<Image condition="image">msiexec.exe</Image>
+				<CommandLine condition="contains any">/i;-i</CommandLine>
+				<CommandLine condition="contains any">http</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Rundll32-->
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=4,Alert=Rundll32 Suspicious call by Ordinal,Risk=80" groupRelation="and">
+				<OriginalFileName condition="is">RUNDLL32.EXE</OriginalFileName>
+				<CommandLine condition="contains all">,;#</CommandLine>
+				<CommandLine condition="excludes">C:\Windows\resources\themes\Aero\AeroLite.msstyles</CommandLine>
+				<CommandLine condition="excludes">uxtheme.dll</CommandLine>
+				<CommandLine condition="excludes">ImageView_Fullscreen</CommandLine>
+				<CommandLine condition="excludes">EDGEHTML.dll</CommandLine>
+				<CommandLine condition="excludes">PhotoViewer.dll</CommandLine>
+				<CurrentDirectory condition="excludes">\AppData\Local\WebEx\WebEx\</CurrentDirectory>
+			</Rule>
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=3,Alert=Rundll32 Single Threaded Apartment Switch - check for com hijacks,Risk=75" groupRelation="and">
+				<OriginalFileName condition="is">RUNDLL32.EXE</OriginalFileName>
+				<CommandLine condition="contains any">-sta;/sta</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=Suspicious OpenAs_RunDLL,Risk=30" groupRelation="and">
+				<OriginalFileName condition="is">RUNDLL32.EXE</OriginalFileName>
+				<CommandLine condition="contains all">shell32.dll;OpenAs_RunDLL</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=Executing Powershell,Risk=70" groupRelation="and">
+				<ParentImage condition="image">RUNDLL32.EXE</ParentImage>
+				<OriginalFileName condition="contains">powershell</OriginalFileName>
+			</Rule>
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=Suspicious OpenURL Commands" groupRelation="and">
+				<OriginalFileName condition="is">RUNDLL32.EXE</OriginalFileName>
+				<CommandLine condition="contains all">url.dll;OpenURL</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=Suspicious FileProtocolHandler Commands" groupRelation="and">
+				<OriginalFileName condition="is">RUNDLL32.EXE</OriginalFileName>
+				<CommandLine condition="contains all">url.dll;FileProtocolHandler</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=Suspicious RouteTheCall Commands" groupRelation="and">
+				<OriginalFileName condition="is">RUNDLL32.EXE</OriginalFileName>
+				<CommandLine condition="contains all">zipfldr.dll;RouteTheCall</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=Suspicious Control_RunDLL Commands" groupRelation="and">
+				<OriginalFileName condition="is">RUNDLL32.EXE</OriginalFileName>
+				<CommandLine condition="contains all">Shell32.dll;Control_RunDLL</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=Suspicious javascript Commands" groupRelation="and">
+				<OriginalFileName condition="is">RUNDLL32.EXE</OriginalFileName>
+				<CommandLine condition="contains">javascript:</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=Suspicious RegisterXLL Commands" groupRelation="and">
+				<OriginalFileName condition="is">RUNDLL32.EXE</OriginalFileName>
+				<CommandLine condition="contains">RegisterXLL</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=4,Alert=Suspicious Rundll32 loading in Public User folder" groupRelation="and">
+				<Image condition="image">rundll32.exe</Image> 
+				<CommandLine condition="contains all">C:\Users;Public</CommandLine>
+				<ParentCommandLine condition="excludes any">rdpinit.exe</ParentCommandLine> 
+				<ParentImage condition="excludes any">rdpinit.exe;G2MInstaller;GoToMeeting;LogMeIn;firefox.exe</ParentImage> 
+			</Rule>
+			<Rule name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=4,Alert=Suspicious Rundll32 loading in Appdata Temp" groupRelation="and">
+				<Image condition="image">rundll32.exe</Image>
+				<CommandLine condition="contains all">C:\Users;Appdata;Temp</CommandLine>
+				<CommandLine condition="excludes any">ImageView_</CommandLine>
+				<ParentCommandLine condition="excludes any">rdpinit.exe</ParentCommandLine>
+				<ParentImage condition="excludes any">rdpinit.exe;G2MInstaller;GoToMeeting;LogMeIn;firefox.exe</ParentImage>
+			</Rule>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=LOLbin" condition="contains all">advpack.dll;LaunchINFSection</CommandLine>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=LOLbin" condition="contains all">ieadvpack.dll;LaunchINFSection</CommandLine>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=LOLbin" condition="contains all">syssetup.dll;SetupInfObjectInstallAction</CommandLine>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=0,Desc=LOLbin" condition="contains all">setupapi.dll;InstallHinfSection</CommandLine>
+			<CommandLine condition="contains">InstallHinfSection</CommandLine>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">infDefaultInstall.exe</Image>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=4,Alert=APT28 CHOPSTICK Detection,Risk=70" condition="contains">rundll32.exe "C:\Windows\twain_64.dll"</CommandLine>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=4,Alert=Shdocvw exec via rundll32,Risk=70" condition="contains all">shdocvw.dll;OpenURL</CommandLine>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=4,Alert=Testing advpack exec,Risk=70" condition="contains all">advpack.dll;RegisterOCX</CommandLine>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=4,Alert=EDR Bypass,Risk=100" condition="contains all">Zipfldr.dll;RouteTheCall</CommandLine>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=4,Alert=EDR Bypass,Risk=100" condition="contains all">url.dll;FileProtocolHandler</CommandLine>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=4,Alert=EDR Bypass technique FileProtocolHandler,Risk=100" condition="contains all">url.dll;FileProtocolHandler</CommandLine>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=4,Alert=EDR Bypass OpenURLA,Risk=100" condition="contains all">OpenURLA;file:</CommandLine>
+			<CommandLine name="Attack=T1218.011,Technique=Rundll32,Tactic=Defense Evasion,Level=4,Alert=EDR Bypass OpenURLA,Risk=100" condition="contains all">OpenURL;file:</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: MSHTA-->
+			<Rule name="Attack=T1059,Technique=Scripting,Tactic=Defense Evasion,Level=4,Alert=Suspicious child processes of mshta,Risk=100" groupRelation="and">
+				<ParentImage condition="image">mshta.exe</ParentImage>
+				<Image condition="contains any">cmd.exe;powershell.exe;wscript.exe;cscript.exe;sh.exe;bash.exe;reg.exe;regsvr32.exe;bitsadmin</Image>
+			</Rule>
+			<Rule name="Attack=T1170,Technique=MSHTA,Tactic=Defense Evasion,Level=4,Alert=MSHTA Execution,Risk=100" groupRelation="and">
+				<Image condition="image">mshta.exe</Image>
+			</Rule>
+			<CommandLine name="Attack=T1170,Technique=MSHTA,Tactic=Defense Evasion,Level=4,Alert=MSHTA Execution" condition="contains">RunHTMLApplication</CommandLine>
+			<CommandLine name="Attack=T1170,Technique=MSHTA,Tactic=Defense Evasion,Level=4,Alert=MSHTA Execution" condition="contains">mshtml</CommandLine>
+			<CommandLine name="Attack=T1170,Technique=MSHTA,Tactic=Defense Evasion,Level=4,Alert=MSHTA Execution" condition="contains">vbscript:CreateObject</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Odbcconf-->
+			<Image name="Attack=T1218.008,Technique=System Binary Proxy Execution,Tactic=Defense Evasion,Level=3,Alert=Possible driver load with odbcconf,Risk=40" condition="image">odbcconf.exe</Image>
+
+			<!--MITRE ATT&CK TECHNIQUE: System Script Proxy Execution-->
+			<CommandLine name="Attack=T1216,Technique=System Script Proxy Execution,Tactic=Defense Evasion,Level=4,Alert=manage-bde.wsf exec,Risk=100" condition="contains">manage-bde.wsf</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Template Injection-->
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Trusted Developer Utilities Proxy Execution-->
+			<Rule name="Attack=T1127.001,Technique=Trusted Developer Utilities,Tactic=Defense Evasion,Level=4,Alert=Powershell Calling MSBuild" groupRelation="and">
+				<ParentImage condition="contains any">powershell.exe;powershell_ise.exe</ParentImage>
+				<Image condition="image">msbuild.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1127.001,Technique=Trusted Developer Utilities,Tactic=Defense Evasion,Level=4,Alert=MSBuild Calling RegAsm" groupRelation="and">
+				<ParentImage condition="image">msbuild.exe</ParentImage>
+				<Image condition="contains">regasm</Image>
+			</Rule>
+			<Rule name="Attack=T1127.001,Technique=Trusted Developer Utilities,Tactic=Defense Evasion,Level=4,Alert=MSBuild Calling useinit" groupRelation="and">
+				<ParentImage condition="image">msbuild.exe</ParentImage>
+				<Image condition="image">userinit.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1127.001,Technique=Trusted Developer Utilities,Tactic=Defense Evasion,Level=4,Alert=MSBuild Building from xml - Silent Trinity" groupRelation="and">
+				<ParentImage condition="image">msbuild.exe</ParentImage>
+				<ParentCommandLine condition="contains">.xml</ParentCommandLine>
+			</Rule>
+			<Rule name="Attack=T1127.001,Technique=Trusted Developer Utilities,Tactic=Defense Evasion,Level=4,Alert=RegAsm Parent process" groupRelation="and">
+				<ParentImage condition="image">regasm.exe</ParentImage>
+				<Image condition="excludes">\conhost.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1127.001,Technique=Trusted Developer Utilities,Tactic=Defense Evasion,Level=4,Alert=MSBuild building from lnk file" groupRelation="and">
+				<Image condition="image">msbuild.exe</Image>
+				<CommandLine condition="contains">.lnk</CommandLine>
+			</Rule>
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">.csproj</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Unused/Unsupported Cloud Regions-->
+			<!--MITRE ATT&CK TECHNIQUE: Use Alternate Authentication Material-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Virtualization/Sandbox Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Weaken Encryption-->
+			<!--MITRE ATT&CK TECHNIQUE: XSL Script Processing-->
+			<Image name="Attack=T1220,Technique=XSL Script Processing,Tactic=Defense Evasion Execution,Level=4,Alert=XSL Script Processing" condition="image">msxsl.exe</Image>
+			<ParentImage name="Attack=T1220,Technique=XSL Script Processing,Tactic=Defense Evasion Execution,Level=4,Alert=XSL Script Processing" condition="image">msxsl.exe</ParentImage>
+			<!--MITRE ATT&CK TACTIC: Credential Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Adversary-in-the-Middle-->
+			<!--MITRE ATT&CK TECHNIQUE: Brute Force-->
+			<!--MITRE ATT&CK TECHNIQUE: Credentials from Password Stores-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Credential Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Forced Authentication-->
+			<!--MITRE ATT&CK TECHNIQUE: Forge Web Credentials-->
+			<!--MITRE ATT&CK TECHNIQUE: Input Capture-->
+			<CommandLine name="Attack=T1056.001,Technique=Input Capture: Keylogging,Tactic=Credential Access,Level=4,Alert=Possible Hawkeye Keylogger Detected" condition="contains">/stext</CommandLine>
+			<CommandLine name="Attack=T1056.001,Technique=Input Capture: Keylogging,Tactic=Credential Access,Level=4,Alert=Possible Keylogger Detected" condition="contains">keylog</CommandLine>
+			<CommandLine name="Attack=T1056.001,Technique=Input Capture: Keylogging,Tactic=Credential Access,Level=4,Alert=Possible Keylogger Detected" condition="contains">keyscan_</CommandLine>
+			<CommandLine name="Attack=T1056.001,Technique=Input Capture: Keylogging,Tactic=Credential Access,Level=4,Alert=Possible Keylogger Detected" condition="contains">Get-Keystrokes</CommandLine>
+			<CommandLine name="Attack=T1056.001,Technique=Input Capture: Keylogging,Tactic=Credential Access,Level=4,Alert=Possible Keylogger Detected" condition="contains">/scomma</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Factor Authentication Interception-->
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Factor Authentication Request Generation-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Sniffing-->
+			<Rule name="Attack=T1040,Technique=Network Sniffing,Tactic=Credential Access/Discovery,Level=4,Alert=Network Sniffing tool Detected,Risk=100" groupRelation="and">
+				<CommandLine condition="contains">sniff</CommandLine>
+				<CommandLine condition="excludes">C:\Program Files\Adobe\</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1040,Technique=Network Sniffing,Tactic=Credential Access/Discovery,Level=4,Alert=PCAP Sniffing tool Detected,Risk=100" groupRelation="or">
+				<OriginalFileName condition="is any">tcpdump.exe;tcpdump.c;tshark.exe;tshark.c;windump.exe;windump.c;wireshark.c;wireshark.exe</OriginalFileName>
+				<CommandLine condition="contains any">windump;tshark;tcpdump;windump;wireshark</CommandLine>
+				<CommandLine condition="contains all">netsh;trace;start;capture=yes</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: OS Credential Dumping-->
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Access with vss shadow copy,Risk=100" groupRelation="and">
+				<Image condition="image">vssadmin.exe</Image>
+				<CommandLine condition="contains any">create;shadow</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential access with wmic shadow copy creation,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">wmic.exe</OriginalFileName>
+				<CommandLine condition="contains all">shadowcopy;call;create</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential access with wmic esentutl,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">wmic.exe</OriginalFileName>
+				<CommandLine condition="contains all">call;create;esentutl;vss</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Powershell shadow copy creation,Risk=100" groupRelation="and">
+				<CommandLine condition="contains all">win32_shadowcopy;create;clientaccessible</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Symlink to Shadowcopy,Risk=100" groupRelation="and">
+				<CommandLine condition="contains all">mklink;GLOBALROOT;Shadow</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Copy of NTDS.dit from vss shadow copy,Risk=100" groupRelation="or">
+				<CommandLine condition="contains all">copy;NTDS\ntds.dit</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=ntdsutil credential dumping,Risk=100" groupRelation="or">
+				<Image condition="image">ntdsutil.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Copy of SYSTEM Registry from vss shadow copy,Risk=100" groupRelation="or">
+				<CommandLine condition="contains all">copy;System32\config\SYSTEM</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Malicious Reg Save Credential Dumping,Risk=100" groupRelation="or">
+				<CommandLine condition="contains all">reg;save;HKLM</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Command Mimikatz,Risk=100" groupRelation="and">
+				<CommandLine condition="contains any">mimikatz;mimidrv;mimilove;mimilib;sekurlsa;lsadump;dumpcreds;privilege::;token::;logonpasswords;mimikittenz;mimiauth;::;kerberos::;misc::skeleton;privilege::debug;dpapi::cred;vault::cred;lsadump;misc::;Krbtgt;TOKEN::;invoke-mimi</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=3,Alert=Possible credential modification or disclosure with cmdkey,Risk=30" groupRelation="and">
+				<OriginalFileName condition="contains">cmdkey</OriginalFileName>
+			</Rule>
+			<OriginalFileName name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=3,Alert=Credential Dumping Command rpcping,Risk=100" condition="is">rpcping.exe</OriginalFileName>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Command nltest,Risk=100" condition="contains">nltest.exe</CommandLine>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Suspicious Cred Dumping Commands,Risk=60" groupRelation="and">
+				<CommandLine condition="contains any">-ma lsass.exe;Do-Exfiltration;Powersploit;GPPPassword;gpprefdecrypt;gsecdump;hashdump;laZagne;ntds.dit;ppldump;pwdump;pwdumpx;secretsdump;/listcreds:;-listcreds:</CommandLine>
+			</Rule>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Via vaultcli.dll" condition="contains">VaultCloseVault</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Via vaultcli.dll" condition="contains">VaultEnumerateItem</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Via vaultcli.dll" condition="contains">VaultFree</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Via vaultcli.dll" condition="contains">VaultGetItem</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Via vaultcli.dll" condition="contains">VaultOpenVault</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Via vaultcli.dll" condition="contains">Vaultcmd</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Via vaultcli.dll" condition="contains">vaultcli.dll</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping from firefox" condition="contains">select * from moz_login</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping" condition="contains">Invoke-WinEnum</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Dumping Cached Credentials,Risk=100" condition="contains">System.Net.CredentialCache</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=VSS Shadow file Created" condition="contains">create shadow</CommandLine>
+			<CommandLine name="Attack=T1003,Technique=OS Credential Dumping,Tactic=Credential Dumping,Level=4,Alert=Credential Theft: netsh wlan password export in cleartext,Risk=100" condition="contains all">wlan;export;profile;key=clear</CommandLine>
+			<CommandLine name="Attack=T1003.006,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Command DCsync,Risk=100" condition="contains">dcsync</CommandLine>
+			<CommandLine name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Level=4,Alert=Credentials in Registry" condition="contains any">HKCU /f password;HKCU -f password</CommandLine>
+			<CommandLine name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Level=4,Alert=Credentials in Registry" condition="contains any">HKLM /f password;HKLM -f password</CommandLine>
+			<Image name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Command nltest,Risk=60" condition="image">nltest.exe</Image>
+			<Image name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Command" condition="contains">ProcDump.exe</Image>
+			<OriginalFileName name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping Command" condition="contains">ProcDump</OriginalFileName>
+			<!--MITRE ATT&CK TECHNIQUE: Steal Application Access Token-->
+			<!--MITRE ATT&CK TECHNIQUE: Steal or Forge Kerberos Tickets-->
+			<CommandLine name="Attack=T1558,Technique=Steal or Forge Kerberos Tickets,Tactic=Credential Access,Level=4,Alert=Steal or Forge Kerberos Tickets,Risk=70" condition="contains any">asktgt;asktgs</CommandLine>
+			<CommandLine name="Attack=T1558,Technique=Steal or Forge Kerberos Tickets,Tactic=Credential Access,Level=4,Alert=Steal or Forge Kerberos Tickets,Risk=70" condition="contains any">createnetonly /program:;createnetonly -program:</CommandLine>
+			<CommandLine name="Attack=T1558,Technique=Steal or Forge Kerberos Tickets,Tactic=Credential Access,Level=4,Alert=Steal or Forge Kerberos Tickets,Risk=70" condition="contains any">dump /service:krbtgt;dump -service:krbtgt</CommandLine>
+			<CommandLine name="Attack=T1558,Technique=Steal or Forge Kerberos Tickets,Tactic=Credential Access,Level=4,Alert=Steal or Forge Kerberos Tickets,Risk=70" condition="contains any">harvest /interval:;harvest -interval:</CommandLine>
+			<CommandLine name="Attack=T1558,Technique=Steal or Forge Kerberos Tickets,Tactic=Credential Access,Level=4,Alert=Steal or Forge Kerberos Tickets,Risk=70" condition="contains any">renew /ticket:;renew -ticket:</CommandLine>
+			<CommandLine name="Attack=T1558,Technique=Steal or Forge Kerberos Tickets,Tactic=Credential Access,Level=4,Alert=Steal or Forge Kerberos Tickets,Risk=70" condition="contains">asreproast</CommandLine>
+			<CommandLine name="Attack=T1558,Technique=Steal or Forge Kerberos Tickets,Tactic=Credential Access,Level=4,Alert=Steal or Forge Kerberos Tickets,Risk=70" condition="contains">impersonateuser:</CommandLine>
+			<CommandLine name="Attack=T1558,Technique=Steal or Forge Kerberos Tickets,Tactic=Credential Access,Level=4,Alert=Steal or Forge Kerberos Tickets,Risk=70" condition="contains">kerberoast</CommandLine>
+			<CommandLine name="Attack=T1558,Technique=Steal or Forge Kerberos Tickets,Tactic=Credential Access,Level=4,Alert=Steal or Forge Kerberos Tickets,Risk=70" condition="contains">ptt /ticket:</CommandLine>
+			<Image name="Attack=T1558,Technique=Steal or Forge Kerberos Tickets,Tactic=Credential Access,Level=4,Alert=Kerberos Ticket Disclosure with klist,Risk=70" condition="image">klist.exe</Image>
+			<Image name="Attack=T1558,Technique=Steal or Forge Kerberos Tickets,Tactic=Credential Access,Level=0,Desc=Kerberos Ticket Disclosure,Risk=30" condition="image">hh.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Steal Web Session Cookie-->
+			<!--MITRE ATT&CK TECHNIQUE: Unsecured Credentials-->
+			<Rule name="Attack=T1552,Technique=Unsecured Credentials,Tactic=Credential Access,Level=3,Alert=Possible disclosure with IIS appcmd,Risk=100" groupRelation="and">
+				<OriginalFileName condition="is">appcmd.exe</OriginalFileName>
+				<CommandLine condition="contains all">list;text;password</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TACTIC: Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Account Discovery -->
+			<Image name="Attack=T1087,Technique=Account Discovery,Tactic=Discovery,Level=2,Alert=User enumeration/Discovery,Risk=30" condition="image">quser.exe</Image>
+			<Rule name="Attack=T1087,Technique=Account Discovery,Tactic=Discovery,Level=2,Alert=User or Group Discovery,Risk=50" groupRelation="and">
+				<OriginalFileName condition="contains any">net.exe;net1.exe;net2.exe</OriginalFileName>
+				<CommandLine condition="contains any">group;localgroup; user</CommandLine>
+				<CommandLine condition="excludes">/domain</CommandLine>
+				<CommandLine condition="excludes">SUService</CommandLine>
+				<CommandLine condition="excludes">\users</CommandLine>
+				<ParentCommandLine condition="excludes">tvsu_tmp</ParentCommandLine>
+			</Rule>
+			<Rule name="Attack=T1087,Technique=Account Discovery,Tactic=Discovery,Level=2,Alert=Domain User or Group Discovery,Risk=50" groupRelation="and">
+				<OriginalFileName condition="contains any">net.exe;net1.exe;net2.exe</OriginalFileName>
+				<CommandLine condition="contains any">group;localgroup; user</CommandLine>
+				<CommandLine condition="contains any">/domain</CommandLine>
+				<CommandLine condition="excludes">SUService</CommandLine>
+				<CommandLine condition="excludes">\users</CommandLine>
+				<ParentCommandLine condition="excludes">tvsu_tmp</ParentCommandLine>
+			</Rule>
+			<Rule name="Attack=T1087,Technique=Account Discovery,Tactic=Discovery,Level=4,Alert=Sharphound Discovery,Risk=100" groupRelation="or">
+				<CommandLine condition="contains any">sharphound;bloodhound;azurehound;CollectionMethod;encryptzip;randomizefilenames;dumpcomputerstatus</CommandLine>
+				<Company condition="contains any">sharphound;bloodhound</Company>
+				<Description condition="contains any">sharphound;bloodhound</Description>
+				<Image condition="contains any">sharphound;bloodhound</Image>
+				<OriginalFileName condition="contains any">sharphound;bloodhound</OriginalFileName>
+				<ParentImage condition="contains any">sharphound;bloodhound</ParentImage>
+				<Product condition="contains any">sharphound;bloodhound</Product>
+			</Rule>
+			<CommandLine name="Attack=T1087,Technique=Account Discovery,Tactic=Discovery,Level=3,Alert=DSclient Discovery,Risk=70" condition="contains any">dscl . list /Groups;dscl . list -Groups</CommandLine>
+			<CommandLine name="Attack=T1087,Technique=Account Discovery,Tactic=Discovery,Level=3,Alert=DSclient Discovery,Risk=70" condition="contains any">dscl . list /Users;dscl . list -Users</CommandLine>
+			<Image name="Attack=T1087,Technique=Account Discovery,Tactic=Discovery,Level=3,Alert=DSQuery.EXE Discovery,Risk=70" condition="image">dsquery.exe</Image>
+			<Image name="Attack=T1087,Technique=Account Discovery,Tactic=Discovery,Level=3,Alert=Query.EXE Discovery,Risk=30" condition="image">query.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Application Window Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Bookmark Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Infrastructure Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Service Dashboard-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Storage Object Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Container and Resource Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Debugger Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Trust Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: File and Directory Discovery-->
+			<Image name="Attack=T1083,Technique=File and Directory Discovery,Tactic=Discovery,Level=0,Desc=directory structure disclosure,Risk=30" condition="end with">tree.com</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Group Policy Discovery-->
+			<Rule name="Attack=T1484.001,Technique=Group Policy Discovery,Tactic=Discovery,Level=3,Alert=Auditpol System/GP Audit Policy Discovery" groupRelation="and">
+				<OriginalFileName condition="contains">auditpol</OriginalFileName>
+				<CommandLine condition="contains any">/get;-get;/list;-list;/backup;-backup</CommandLine>
+			</Rule>
+			<Image name="Attack=T1484.001,Technique=Group Policy Discovery,Tactic=Discovery,Level=3,Alert=Group Policy Discovery with GPResult" condition="contains any">gpresult.exe</Image>
+			<CommandLine name="Attack=T1484.001,Technique=Group Policy Discovery,Tactic=Discovery,Level=3,Alert=Group Policy Discovery with Powershell" condition="contains any">get-gpo;get-gpresult;get-gpreg</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Network Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Share Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Sniffing-->
+			<!--MITRE ATT&CK TECHNIQUE: Password Policy Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Peripheral Device Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Permission Groups Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Discovery-->
+			<Image name="Attack=T1057,Technique=Process Discovery,Tactic=Discovery,Level=0,Desc=Process Discovery,Risk=0" condition="image">tasklist.exe</Image>
+			<Image name="Attack=T1057,Technique=Process Discovery,Tactic=Discovery,Level=3,Alert=Process Discovery,Risk=0" condition="image">qprocess.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Query Registry-->
+			<CommandLine name="Attack=T1012,Technique=Query Registry,Tactic=Discovery,Level=0,Desc=System information discovery with reg.exe,Risk=20" condition="contains">reg query</CommandLine>
+			<CommandLine name="Attack=T1012,Technique=Query Registry,Tactic=Discovery,Level=0,Desc=System information discovery with reg.exe,Risk=20" condition="contains">reg.exe query</CommandLine>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">driverquery.exe</Image><!-- Remote Driver querying-->
+
+			<!--MITRE ATT&CK TECHNIQUE: Remote System Discovery-->
+			<Image name="Attack=T1018,Technique=Remote System Discovery,Tactic=Discovery,Level=2,Alert=Traceroute Remote System Discovery,MitreURL=https://attack.mitre.org/techniques/T1018/,Risk=30" condition="image">tracert.exe</Image>
+			<Image name="Attack=T1018,Technique=Remote System Discovery,Tactic=Discovery,Level=2,Alert=Pathping Remote System Discovery,MitreURL=https://attack.mitre.org/techniques/T1018/,Risk=30" condition="image">pathping.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Software Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Discovery: Security Software Discovery-->
+			<Rule name="Attack=T1063,Technique=Security Software Discovery,Tactic=Discovery,Alert=Sysmon Detection with driver altitude " groupRelation="or">
+				<CommandLine condition="contains all">find;385201</CommandLine>
+				<CommandLine condition="contains all">select-string;385201</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1063,Technique=Security Software Discovery,Tactic=Discovery,Alert=Antivirus/edr/siem Discovery" groupRelation="or">
+				<CommandLine condition="contains all">find;virus</CommandLine>
+				<CommandLine condition="contains all">select-string;virus</CommandLine>
+				<CommandLine condition="contains all">process;Description;virus</CommandLine>
+				<CommandLine condition="contains all">find;cb</CommandLine>
+				<CommandLine condition="contains all">select-string;cb</CommandLine>
+				<CommandLine condition="contains all">process;Description;cb</CommandLine>
+				<CommandLine condition="contains all">find;defender</CommandLine>
+				<CommandLine condition="contains all">select-string;defender</CommandLine>
+				<CommandLine condition="contains all">process;Description;defender</CommandLine>
+				<CommandLine condition="contains all">find;crowdstrike</CommandLine>
+				<CommandLine condition="contains all">select-string;crowdstrike</CommandLine>
+				<CommandLine condition="contains all">process;Description;crowdstrike</CommandLine>
+				<CommandLine condition="contains all">find;sentinel</CommandLine>
+				<CommandLine condition="contains all">select-string;sentinel</CommandLine>
+				<CommandLine condition="contains all">process;Description;sentinel</CommandLine>
+				<CommandLine condition="contains all">find;nessusd</CommandLine>
+				<CommandLine condition="contains all">select-string;nessusd</CommandLine>
+				<CommandLine condition="contains all">process;Description;nessusd</CommandLine>
+				<CommandLine condition="contains all">find;td-agent</CommandLine>
+				<CommandLine condition="contains all">select-string;td-agent</CommandLine>
+				<CommandLine condition="contains all">process;Description;td-agent</CommandLine>
+				<CommandLine condition="contains all">find;cbagentd</CommandLine>
+				<CommandLine condition="contains all">select-string;cbagentd</CommandLine>
+				<CommandLine condition="contains all">process;Description;cbagentd</CommandLine>
+				<CommandLine condition="contains all">find;sysmon</CommandLine>
+				<CommandLine condition="contains all">select-string;sysmon</CommandLine>
+				<CommandLine condition="contains all">process;Description;sysmon</CommandLine>
+				<CommandLine condition="contains all">find;winlogbeat</CommandLine>
+				<CommandLine condition="contains all">select-string;winlogbeat</CommandLine>
+				<CommandLine condition="contains all">process;Description;winlogbeat</CommandLine>
+				<CommandLine condition="contains all">find;winlogbeat</CommandLine>
+				<CommandLine condition="contains all">select-string;winlogbeat</CommandLine>
+				<CommandLine condition="contains all">process;Description;winlogbeat</CommandLine>
+				<CommandLine condition="contains all">find;csfalcon</CommandLine>
+				<CommandLine condition="contains all">select-string;csfalcon</CommandLine>
+				<CommandLine condition="contains all">process;Description;csfalcon</CommandLine>
+				<CommandLine condition="contains all">find;splunk</CommandLine>
+				<CommandLine condition="contains all">select-string;splunk</CommandLine>
+				<CommandLine condition="contains all">process;Description;splunk</CommandLine>
+				<CommandLine condition="contains all">find;sidecar</CommandLine>
+				<CommandLine condition="contains all">select-string;sidecar</CommandLine>
+				<CommandLine condition="contains all">process;Description;sidecar</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1063,Technique=Security Software Discovery,Tactic=Discovery" groupRelation="or">
+				<OriginalFileName name="Attack=T1063,Technique=Security Software Discovery,Tactic=Discovery" condition="is">fltMC.exe</OriginalFileName>
+				<CommandLine name="Attack=T1063,Technique=Security Software Discovery,Tactic=Discovery" condition="contains">misc::mflt</CommandLine>
+			</Rule>
+			<CommandLine name="Attack=T1016,Technique=Security Software Discovery,Tactic=Discovery,Level=3,Alert=AV Product detection via WMI,Risk=30" condition="contains">AntiVirusProduct</CommandLine>
+			<CommandLine name="Attack=T1016,Technique=Security Software Discovery,Tactic=Discovery,Level=3,Alert=Security Settings via WMI,Risk=30" condition="contains">root\SecurityCenter2</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: System Information Discovery-->
+			<Image name="Attack=T1016,Technique=System Information Discovery,Tactic=Discovery,Level=2,Alert=System Information Discovery,Risk=30" condition="image">sysinfo.exe</Image>
+			<CommandLine name="Attack=T1016,Technique=System Information Discovery,Tactic=Discovery,Level=2,Alert=System Information Discovery,Risk=30" condition="image">systeminfo</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: System Location Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Network Configuration Discovery-->
+			<Rule name="Attack=T1016,Technique=System Network Configuration Discovery,Tactic=Discovery,Level=0,Desc=Network Connection Discovery with netsh,Risk=60" groupRelation="and">
+				<Image condition="image">netsh.exe</Image>
+				<CommandLine condition="contains any">get;list;show</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1016,Technique=System Network Configuration Discovery,Tactic=Discovery,Level=0,Desc=Network Connection Changes with netsh,Risk=60" groupRelation="and">
+				<Image condition="image">netsh.exe</Image>
+				<CommandLine condition="excludes any">get;list;show</CommandLine>
+			</Rule>
+			<Image name="Attack=T1016,Technique=System Network Configuration Discovery,Tactic=Discovery,Level=0,Desc=ipconfig discovery,Risk=20" condition="image">ipconfig.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: System Network Connections Discovery-->
+			<Image name="Attack=T1049,Technique=System Network Connections Discovery,Tactic=Discovery,Level=0,Desc=System Network Connections Discovery,Risk=0" condition="image">netstat.exe</Image>
+			<CommandLine name="Attack=T1049,Technique=System Network Connections Discovery,Tactic=Discovery,Level=2,Alert=ARP Table Lookup Detected,Risk=30" condition="contains">arp -a</CommandLine> 
+			<CommandLine name="Attack=T1049,Technique=System Network Connections Discovery,Tactic=Discovery,Level=2,Alert=ARP Table Lookup Detected,Risk=30" condition="contains">arp.exe -a</CommandLine> 
+			<CommandLine name="Attack=T1049,Technique=System Network Connections Discovery,Tactic=Discovery,Level=2,Alert=ARP Table Lookup Detected,Risk=30" condition="contains">arp  -a</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: System Owner/User Discovery-->
+			<Rule name="Attack=T1033,Technique=System Owner/User Discovery,Tactic=Discovery,Level=2,Alert=Account Discovery,Risk=50" groupRelation="and">
+				<Image condition="contains any">whoami.exe;whoami1.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1033,Technique=System Owner/User Discovery,Tactic=Discovery,Level=3,Alert=WMIC Account Discovery,Risk=30" groupRelation="and">
+				<OriginalFileName condition="contains">wmic.exe</OriginalFileName>
+				<CommandLine condition="contains all">get;useraccount</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1016,Technique=System Network Connections Discovery,Tactic=Discovery,Level=0,Desc=Network Connection modifications with netsh,Risk=40" groupRelation="and">
+				<Image condition="image">netsh.exe</Image>
+				<CommandLine condition="contains any">add;del;set</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1049,Technique=System Network Connections Discovery,Tactic=Discovery,Level=2,Alert=NBTStat DNS Lookup,Risk=30" groupRelation="and">
+				<CommandLine condition="contains">nbtstat</CommandLine> 
+				<CommandLine condition="excludes">nessus</CommandLine> 
+			</Rule>
+			<Rule name="Attack=T1016,Technique=System Network Configuration Discovery,Tactic=Discovery,Level=0,Desc=route.exe discovery,Risk=60" groupRelation="and">
+				<Image condition="image">route.exe</Image>
+				<CommandLine condition="contains">print</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1016,Technique=System Network Configuration Discovery,Tactic=Discovery,Level=0,Desc=Route Modification,Risk=40" groupRelation="and">
+				<Image condition="image">route.exe</Image>
+				<CommandLine condition="contains any">ADD;DEL;CHANGE;-f</CommandLine>
+			</Rule>
+			<Image name="Attack=T1033,Technique=System Owner/User Discovery,Tactic=Discovery,Level=2,Alert=User enumeration with qwinsta" condition="image">qwinsta.exe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">rwinsta.exe</Image>
+			
+			<!--MITRE ATT&CK TECHNIQUE: System Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Time Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Virtualization/Sandbox Evasion-->
+
+			<!--MITRE ATT&CK TACTIC: Lateral Movement-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ParentImage condition="contains">Microsoft Office\root\Office</ParentImage>
+				<Image condition="excludes">Microsoft Office\root\Office</Image>
+				<ParentCommandLine condition="contains all">automation;Embedding</ParentCommandLine>
+			</Rule>
+			<Rule name="Attack=T1021.002,Tactic=Lateral Movement,Technique=SMB/Windows Admin Shares,Level=3,Alert=Command Ran over Admin Share" groupRelation="and">
+				<CommandLine condition="contains">admin$</CommandLine>
+				<CommandLine condition="excludes any">davclnt.dll</CommandLine>
+				<ParentCommandLine condition="excludes any">WebClientGroup</ParentCommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation of Remote Services-->
+			<!--MITRE ATT&CK TECHNIQUE: Internal Spearphishing-->
+			<!--MITRE ATT&CK TECHNIQUE: Lateral Tool Transfer-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote Service Session Hijacking-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote Service Session Hijacking: RDP Hijacking-->
+			<CommandLine name="Attack=T1563.002,Technique=RDP Hijacking,Tactic=Lateral Movement,Level=4,Alert=Remote Desktop Shadow Alert,Risk=100" condition="contains any">/shadow;-shadow</CommandLine>
+			<CommandLine name="Attack=T1563.002,Technique=RDP Hijacking,Tactic=Lateral Movement,Level=4,Alert=Remote Desktop Shadow with no Consent alert" condition="contains">noConsentPrompt</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Remote Services-->
+			<Rule name="Attack=T1076,Technique=Remote Desktop Protocol,Tactic=Lateral Movement,Level=4,Alert=RDP Hijack Detected" groupRelation="and">
+				<ParentImage name="Attack=T1076,Technique=Remote Desktop Protocol,Tactic=Lateral Movement,Level=4,Alert=RDP Hijack Detected,Risk=100" condition="image">tscon.exe</ParentImage>
+				<CommandLine condition="contains">dest:rdp-tcp:</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=4,Alert=Powershell Executed via WMI from recent Emotet Variants,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">powershell.exe</OriginalFileName>
+				<ParentImage condition="image">WmiPrvSE.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=4,Alert=Emotet Executed via WMI,Risk=100" groupRelation="and">
+				<ParentImage condition="image">WmiPrvSE.exe</ParentImage>
+				<Image condition="contains">\Users\</Image>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=Network Detective System Scan Detected,Risk=100" groupRelation="and">
+				<Image condition="contains">NetworkDetective</Image>
+				<ParentImage condition="image">WmiPrvSE.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=Remote Tenable Malware Scan Detected,Risk=100" groupRelation="and">
+				<Image condition="image">sc.exe</Image>
+				<CommandLine condition="contains">tenable</CommandLine>
+				<ParentImage condition="image">WmiPrvSE.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=CMD.exe Executed via WMI from recent Emotet Variants,Risk=100" groupRelation="and">
+				<Image condition="image">cmd.exe</Image>
+				<ParentImage condition="image">WmiPrvSE.exe</ParentImage>
+				<CommandLine condition="excludes any">do_vbsUpload;Spiceworks</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=regsvr32.exe Executed via WMI,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">regsvr32.exe</OriginalFileName>
+				<ParentImage condition="image">WmiPrvSE.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=CMD Executed via WMI,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">cmd.exe</OriginalFileName>
+				<ParentImage condition="image">WmiPrvSE.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=4,Alert=Powershell Executed via WMI from recent Emotet Variants,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">powershell.exe</OriginalFileName>
+				<ParentImage condition="image">WmiPrvSE.exe</ParentImage>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=RSAT Tool Launch,Risk=100" groupRelation="and">
+				<CommandLine condition="contains">dsa.msc</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=HyperV Remote Management Tool Launch,Risk=100" groupRelation="and">
+				<CommandLine condition="contains">virtmgmt.msc</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=Potential Malicious Remote WMI Execution Detected,Risk=100" groupRelation="and">
+				<ParentImage condition="image">wmiprvse.exe</ParentImage>
+				<Image condition="excludes">CompMgmtLauncher.exe</Image>
+				<Image condition="excludes">DismHost.exe</Image>
+				<Image condition="excludes">Microsoft.NET\Framework</Image>
+				<Image condition="excludes">NetEvtFwdr.exe</Image>
+				<Image condition="excludes">ServerManager.exe</Image>
+				<Image condition="excludes">WerFault.exe</Image>
+				<Image condition="excludes">chcp.com</Image>
+				<Image condition="excludes">g2mupdate.exe</Image>
+				<Image condition="excludes">slack.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1021.006,Technique=Remote Services: Windows Remote Management,Tactic=Lateral Movement,Level=3,AlertSuspicious Processes Spawned by WinRM,Risk=100" groupRelation="and">
+				<ParentImage condition="image">wsmprovhost.exe</ParentImage>
+				<Image condition="image">cmd.exe</Image>
+				<Image condition="image">sh.exe</Image>
+				<Image condition="image">bash.exe</Image>
+				<Image condition="image">wsl.exe</Image>
+				<Image condition="image">powershell.exe</Image>
+				<Image condition="image">powershell_ise.exe</Image>
+				<Image condition="image">schtasks.exe</Image>
+				<Image condition="image">at.exe</Image>
+				<Image condition="image">certutil.exe</Image>
+				<Image condition="image">mshta.exe</Image>
+				<Image condition="image">whoami.exe</Image>
+				<Image condition="image">ping.exe</Image>
+				<Image condition="image">ping.exe</Image>
+				<Image condition="image">bitsadmin.exe</Image>
+			</Rule>
+			<Image name="Attack=T1021.006,Technique=Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=Windows Remote Management Execution" condition="end with">winrm.cmd</Image>
+			<Image name="Attack=T1021.006,Technique=Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=WINRS remote shell execution,Risk=100" condition="image">winrs.exe</Image>
+			<Image name="Attack=T1021.006,Technique=Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=WINRS remote shell execution,Risk=100" condition="image">winrshost.exe</Image>
+			<Image name="Attack=T1021.006,Technique=Windows Remote Management,Tactic=Lateral Movement,Level=2,Alert=Waitfor.exe Execution bypass" condition="image">waitfor.exe</Image>
+			<Image name="Attack=T1021.006,Technique=Windows Remote Management,Tactic=Lateral Movement,Level=0,Desc=Windows Remote Management execution" condition="image">wsmprovhost.exe</Image>
+			<ParentImage name="Attack=T1021.006,Technique=Windows Remote Management,Tactic=Lateral Movement,Level=3,Alert=WINRS remote shell execution,Risk=100" condition="end with">winrshost.exe</ParentImage>
+			<ParentImage name="Attack=T1021.006,Technique=Windows Remote Management,Tactic=Lateral Movement,Level=0,Desc=Windows Remote Management execution" condition="image">wsmprovhost.exe</ParentImage>
+			<Rule name="Attack=T1021.006,Technique=Remote WMIC/Execution,Tactic=Lateral Movement,Level=4,Alert=Potential Malicious Document Execution,Risk=90" groupRelation="and">
+				<ParentImage condition="image">wmiprvse.exe</ParentImage>
+				<Image condition="image">mshta.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1021.004,Technique=Remote Services,Tactic=Lateral Movement,Level=4,Alert=Secure Shell Execution,Risk=80" groupRelation="and">
+				<Image condition="contains any">ssh.exe;putty.exe;kitty.exe;kitty_portable.exe</Image><!-- SSH -->
+			</Rule>
+			<Product name="Attack=T1021.004,Technique=Remote Services,Tactic=Lateral Movement,Level=0,Desc=Putty utility detected,Risk=60">PuTTY suite</Product>
+			<Rule name="Attack=T1021.004,Technique=Remote Services,Tactic=Lateral Movement,Level=0,Desc=Secure Shell FTP Execution,Risk=80" groupRelation="and">
+				<Image condition="contains any">sftp;psftp</Image><!-- SSH -->
+			</Rule>
+			<Rule name="Attack=T1021.002,Technique=Remote Services,Tactic=Lateral Movement,Level=4,Alert=Possible SMBExec via Metasploit,Risk=100" groupRelation="and">
+				<CommandLine condition="is">rundll32.exe</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1021.002,Technique=Remote Services,Tactic=Lateral Movement,Level=4,Alert=Trickbot,Risk=100" groupRelation="and">
+				<Image condition="image">rundll32.exe</Image>
+				<CommandLine condition="contains all">..\;,</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1021.002,Technique=Remote Services,Tactic=Lateral Movement,Level=4,Alert=Trickbot 2,Risk=100" groupRelation="and">
+				<Image condition="image">rundll32.exe</Image>
+				<CommandLine condition="contains all">,StartW</CommandLine>
+			</Rule>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=4,Alert=Remote Shutdown with Psexec" condition="contains">psshutdown</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=4,Alert=Sysinternals PSService" condition="contains">psservice</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=4,Alert=Sysinternals PsPasswd" condition="contains">PsPasswd</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">mstsc.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=Telnet Terminal Emulator" condition="image">telnet.exe</Image>
+			<Image name="Level=3,Alert=TFTP Execution" condition="image">tftp.exe</Image>
+			<CommandLine name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=IIS powershellcustomhost exec" condition="contains">powershellcustomhost</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Remote Services: Distributed Component Object Model-->
+			<Rule name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement" groupRelation="and">
+				<ParentCommandLine condition="contains">-Embedding</ParentCommandLine>
+				<ParentImage condition="is">c:\windows\system32\mmc.exe</ParentImage>
+			</Rule>
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=4,Alert=CrackmapExec - Malicious Command Line events,Tactic=Privilege Escalation" condition="contains all">--execm;atexec</CommandLine>
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: Background Intelligent Transfer Control Class 1.0" condition="contains">{4991d34b-80a1-4291-83b6-3328366b9097}</CommandLine>
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: Excel.Application" condition="contains">{00020812-0000-0000-C000-000000000046}</CommandLine> 	  
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: HTML Application" condition="contains">{40AEEAB6-8FDA-41e3-9A5F-8350D4CFCA91}</CommandLine> <!-- -->
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: MMC20.APPLICATION" condition="contains">{7e0423cd-1119-0928-900c-e6d4a52a0715}</CommandLine> <!-- -->
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: Outlook.Application" condition="contains">{0006F04A-0000-0000-C000-000000000046}</CommandLine> <!-- -->
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: Powerpoint.Application" condition="contains">{048EB43E-2059-422F-95E0-557DA96038AF}</CommandLine>
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: Shell.Application" condition="contains">{13709620-C279-11CE-A49E-444553540000}</CommandLine> <!-- -->
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: ShellBrowserWindow" condition="contains">{c08afd90-f2a1-11d1-8455-00a0c91f3880}</CommandLine> <!-- -->
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: ShellWindows" condition="contains">9BA05972-F6A8-11CF-A442-00A0C90A8F39</CommandLine> <!-- -->
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: Visio.Application" condition="contains">{00021A20-0000-0000-C000-000000000046}</CommandLine> <!-- -->
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: WScript.Shell" condition="contains">{72C24DD5-D70A-438B-8A42-98424B88AFB8}</CommandLine> <!-- -->
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM: Word.Application" condition="contains">{00020906-0000-0000-C000-000000000046}</CommandLine>
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=Execution - Suspicious Cmdline - JScript Engine CLSID">{cc5bbec3-db4a-4bed-828d-08d78ee3e1ed}</CommandLine>
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=Execution - Unusual Scripting Engine in use - chakra.dll">{1b7cd997-e5ff-4932-a7a6-2a9e636da385}</CommandLine>
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=Execution - Unusual Scripting Engine in use - jscript9.dll">{16d51579-a30b-4c8b-a276-0ff4dc41e755}</CommandLine>
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=Rundll32 DCOM: CommandLine Execution" condition="contains any">rundll32.exe -sta;rundll32.exe /sta;rundll32 -sta;rundll32 /sta</CommandLine>
+			<CommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=Rundll32 DCOM: CommandLine Execution" condition="contains all">shell32.dll;SHCreateLocalServerRunDll</CommandLine>
+			<ParentCommandLine name="Attack=T1021.003,Technique=Distributed Component Object Model,Tactic=Lateral Movement,Level=0,Desc=DCOM Launch" condition="contains any">-k DcomLaunch;/k DcomLaunch</ParentCommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Replication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Deployment Tools-->
+			<!--MITRE ATT&CK TECHNIQUE: Taint Shared Content-->
+			<!--MITRE ATT&CK TECHNIQUE: Use Alternate Authentication Material-->
+
+			<!--MITRE ATT&CK TACTIC: Collection-->
+			<!--MITRE ATT&CK TECHNIQUE: Adversary-in-the-Middle-->
+			<!--MITRE ATT&CK TECHNIQUE: Archive Collected Data-->
+			<Rule name="Attack=T1195,Technique=Archive Collected Data,Tactic=Collection,Level=4,Alert=Dark Halo Protected zip file creation,Risk=100" groupRelation="and">
+				<Image condition="image">7z.exe</Image>
+				<CommandLine condition="contains any">a -mx9 -r0 -p;a -v500m -mx9 -r0 -p</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Audio Capture-->
+			<CommandLine name="Attack=T1123,Technique=Audio Capture,Tactic=Collection,Level=4,Alert=Audio Capture Detected,Risk=100" condition="contains">WindowsAudioDevice-Powershell-Cmdlet</CommandLine>
+			<CommandLine name="Attack=T1123,Technique=Audio Capture,Tactic=Collection,Level=4,Alert=Audio Capture Detected,Risk=100" condition="contains">SoundRecorder.exe</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Automated Collection-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Session Hijacking-->
+			<!--MITRE ATT&CK TECHNIQUE: Clipboard Data-->
+			<Image name="Attack=T1115,Technique=Clipboard Data,Tactic=Collection,Level=3,Alert=Data injected into clipboard,Risk=30" condition="is">clip.exe</Image>
+			<CommandLine name="Attack=T1115,Technique=Clipboard Data,Tactic=Collection,Level=3,Alert=Data pulled from clipboard,Risk=40" condition="contains">get-clipboard</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Data from Cloud Storage Object-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Configuration Repository-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Information Repositories-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Local System-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Network Shared Drive-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Staged-->
+			<!--MITRE ATT&CK TECHNIQUE: Email Collection-->
+			<Rule name="Attack=T1114,Technique=Email Collection,Tactic=Collection,Level=4,Alert=Possible Email Collection/Exfiltration,Risk=70" groupRelation="and">
+				<CommandLine condition="contains">New-MailboxExportRequest</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Input Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Screen Capture-->
+			<CommandLine name="Attack=T1001,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Screencapture Commands,Risk=100" condition="contains">screencapture</CommandLine>
+			<CommandLine name="Attack=T1001,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Screencapture Commands,Risk=100" condition="contains">system.drawing.Imaging</CommandLine>			
+			<CommandLine name="Attack=T1001,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Screencapture Commands,Risk=100" condition="contains">system.drawing.bitmap</CommandLine>
+			<CommandLine name="Attack=T1001,Technique=Obfuscated Files or Information,Tactic=Defense Evasion,Level=4,Alert=Screencapture Commands,Risk=100" condition="contains">system.windows.forms.screen</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Video Capture-->
+			<!--MITRE ATT&CK TACTIC: Command and Control-->
+			<!--MITRE ATT&CK TECHNIQUE: Application Layer Protocol-->
+			<!--MITRE ATT&CK TECHNIQUE: Communication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Encoding-->
+			<Rule name="Attack=T1132,Technique=Data Encoding,Tactic=Command and Control,Level=4,Alert=base64 encoded URL https or http offset,Risk=80" groupRelation="and">
+				<CommandLine condition="contains any">odHRwczovL;aHR0cDovL;h0dHA6Ly;odHRwOi8v;aHR0cHM6Ly;h0dHBzOi8v</CommandLine>
+				<Image condition="excludes any">ie_to_edge_stub.exe;chrome.exe;firefox.exe;iexplore.exe;brave.exe;vivaldi.exe;msedge.exe;webex;teams.exe;goto opener.exe;lynx.exe;\Webex\webexAppLauncherLatest.exe;\WebEx\webexAppLauncher.exe;\WebEx\Applications\webexAppLauncher.exe;WebEx\webex.exe</Image>
+				<CommandLine condition="excludes any">wbx:;/SITE_TOKEN=;msteams:;PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48cmVxdWVzdCBwcm90b2NvbD0iMy4wIiB1cGRhdGVyPSJPbWFoYSI</CommandLine>
+				<OriginalFileName condition="excludes any">msedgeupdate.dll</OriginalFileName>
+			</Rule>
+			<Rule name="Attack=T1132,Technique=Data Encoding,Tactic=Command and Control,Level=4,Alert=Double Base64 encoded executable,Risk=90" groupRelation="and">
+				<CommandLine condition="contains any">VFZvQUFBQ;RWb0FBQU;UVm9BQUFB;VFZxQUFBR;RWcUFBQU;UVnFBQUFF;VFZwUUFBS;RWcFFBQU;UVnBRQUFJ;VFZxUUFBT;RWcVFBQU;UVnFRQUFN;VFZwVEFRR;RWcFRBUU;UVnBUQVFF</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1132,Technique=Data Encoding,Tactic=Command and Control,Level=4,Alert=base64 encoded powershell" groupRelation="and">
+				<Image condition="image">powershell.exe</Image>
+				<CommandLine condition="contains any">AAAAYInlM;OiCAAAAYInlM;OiJAAAAYInlM;RwBlAHQAL;WwBOAGUAdAAuAFM;W05ldC5TZXJ2aWNl</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1132,Technique=Data Encoding,Tactic=Command and Control,Level=4,Alert=Cyrillic Letter obfuscation,Risk=100" groupRelation="and">
+				<CommandLine condition="contains any">Г;И;К;П;д;и;к;л;л;н;н;о;ф;ե;թ;յ;ն;ն;ն;ն;տ;ւ;ք</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Data Obfuscation-->
+			<!--MITRE ATT&CK TECHNIQUE: Dynamic Resolution-->
+			<!--MITRE ATT&CK TECHNIQUE: Encrypted Channel-->
+			<!--MITRE ATT&CK TECHNIQUE: Fallback Channels-->
+			<!--MITRE ATT&CK TECHNIQUE: Ingress Tool Transfer-->
+			<Rule name="Attack=T1105,Technique=Remote File Copy,Tactic=Command and Control,Level=4,Alert=Certutil file transfer,Risk=100" groupRelation="and">
+				<Image condition="image">certutil.exe</Image>
+				<CommandLine condition="contains all">urlcache;split;f</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=4,Alert=Command Line file transfer,Risk=100" groupRelation="and">
+				<CommandLine condition="contains any">DownloadFile;DownloadString;Net.WebClient;System.Net.WebRequest;System.Net.SecurityProtocolType;Invoke-Expression;Invoke-WebRequest</CommandLine>
+				<Image condition="contains any">powershell.exe;cmd.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=4,Alert=BitsAdmin File Transfers,Risk=70" groupRelation="and">
+				<OriginalFileName condition="is">bitsadmin.exe</OriginalFileName>
+				<CommandLine condition="contains any">CREATE;TRANSFER;DOWNLOAD;UPLOAD;ADDFILE;SetNotifyFlags;SetNotifyCmdLine;SetMinRetryDelay;SetCustomHeaders;RESUME</CommandLine>
+				<CommandLine condition="excludes all">util;setieproxy;localsystem;AUTODETECT</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=4,Alert=BitsAdmin File Transfers 2,Risk=70" groupRelation="and">
+				<Description condition="contains">BITS administration utility</Description><!-- to detect renamed ones -->
+				<CommandLine condition="contains any">CREATE;TRANSFER;DOWNLOAD;UPLOAD;ADDFILE;SetNotifyFlags;SetNotifyCmdLine;SetMinRetryDelay;SetCustomHeaders;RESUME</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1105,Tactic=Command And Control,Technique=Ingress Tool Transfer,Level=4,Alert=Linux Ingress transfer tools on Windows,Risk=30" groupRelation="and">
+				<Image condition="contains any">\curl.exe;\wget.exe;\www.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1105,Tactic=Command And Control,Technique=Ingress Tool Transfer,Level=4,Alert=Linux Ingress transfer tools on Windows,Risk=30" groupRelation="and">
+				<Image condition="contains any">\curl.exe;\wget.exe;\www.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=Certutil file download 1,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">certutil</OriginalFileName>
+				<CommandLine condition="contains all">split;f</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=Certutil file download 2,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">certutil</OriginalFileName>
+				<CommandLine condition="contains any">verifyctl;URL</CommandLine>
+			</Rule>
+			<CommandLine name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=BitsAdmin File Transfers,Risk=70" condition="image">start-bitstransfer</CommandLine>
+			<CommandLine name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=Expand File copy,Risk=70" condition="contains">expand \\</CommandLine>
+			<CommandLine name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=Expand File copy,Risk=70" condition="contains">expand.exe \\</CommandLine>
+			<CommandLine name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=Ingress Tool Transfer with ieexec,Risk=70" condition="contains">ieexec http</CommandLine>
+			<CommandLine name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=Ingress Tool Transfer with ieexec,Risk=70" condition="contains">ieexec.exe http</CommandLine>
+			<CommandLine name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=Ingress Tool Transfer with Powercat,Risk=100" condition="contains">powercat</CommandLine>
+			<CommandLine name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=esentutl Ingress Tool Transfer,Risk=70" condition="contains any">esentutl /y \\;esentutl -y \\</CommandLine>
+			<CommandLine name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=esentutl Ingress Tool Transfer,Risk=70" condition="contains any">esentutl.exe /y \\;esentutl.exe -y \\</CommandLine>
+			<CommandLine name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=extrac32 Ingress Tool Transfer,Risk=70" condition="contains">extrac32 \\</CommandLine>
+			<CommandLine name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=4,Alert=extrac32 Ingress Tool Transfer,Risk=70" condition="contains">extrac32.exe \\</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Stage Channels-->
+			<!--MITRE ATT&CK TECHNIQUE: Non-Application Layer Protocol-->
+			<!--MITRE ATT&CK TECHNIQUE: Non-Standard Port-->
+			<!--MITRE ATT&CK TECHNIQUE: Protocol Tunneling-->
+			<!--MITRE ATT&CK TECHNIQUE: Proxy-->
+			<CommandLine name="Attack=T1090,Technique=Connection Proxy,Tactic=Command and Control,Level=4,Alert=NetSH PortProxy,Risk=70" condition="contains">portproxy</CommandLine>
+			<Image name="Attack=T1090.003,Technique=Proxy: Multi-hop Proxy,Tactic=Command and Control,Level=4,Alert=Tor Detected,Risk=100" condition="image">tor.exe</Image><!-- Tor-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote Access Software-->
+			<Image name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Level=0,Desc=Teamviewer Unattended Session" condition="image">TeamViewer_Desktop.exe</Image>
+			<Rule name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Level=4,Alert=PSExec Command,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains any">psexec</OriginalFileName>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Web Service-->
+
+			<!--MITRE ATT&CK TACTIC: Exfiltration-->
+			<Rule name="Attack=T1020,Technique=Automated Exfiltration,Tactic=Exfiltration,Level=0,Desc=SCP Data exfiltration detected,Risk=100" groupRelation="and">
+				<Image condition="contains any">winscp.exe;winscp.com;scp.exe;pscp</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Automated Exfiltration-->
+			<Rule name="Attack=T1020,Technique=Automated Exfiltration,Tactic=Impact,Level=0,Desc=Data exfiltration Tool detected 3,Risk=100" groupRelation="and">
+				<CommandLine condition="contains any">bitch.exe;bitch.bat;bitch_lasagna.exe;Admin Cracker.exe;BulletsPassView.exe;ChromePass.exe;Dialupass.exe;LSASecretsView.exe;OpenedFilesView.exe;OperaPassView.exe;PasswordFox.exe;ProduKey.exe;RouterPassView.exe;USBDeview.exe;USBStealer.exe;VNCPassView.exe;WebBrowserPassView.exe;WirelessKeyView.exe;WirelessKeyView.exe;empv.exe;netpass.exe;pspv.exe;usbdll.exe;rdpv.exe;WirelessKeyView.exe;lasagna.exe;all -vvv &gt;&gt;;rsync -r</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1020,Technique=Automated Exfiltration,Tactic=Impact,Level=0,Desc=CredsLeaker exfiltration tool detected,Risk=100" groupRelation="and">
+				<CommandLine condition="contains any">CredsLeaker;Windows.Security.Credentials.UI.CredentialPicker;function Leaker;function Await</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1020,Technique=Automated Exfiltration,Tactic=Impact,Level=0,Desc=merlin CnC exfiltration detected 4,Risk=100" groupRelation="and">
+				<CommandLine condition="contains any">.exe -url https://;dll,Run https://;Invoke-Merlin;-m SimpleHTTPServer;/m SimpleHTTPServer</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Data Transfer Size Limits-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Alternative Protocol-->
+			<Rule name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=4,Alert=DNS Exfil detected,Risk=100" groupRelation="and">
+				<CommandLine condition="contains any">-q=txt;/q=txt</CommandLine>
+				<Image condition="image">nslookup.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1567.002,Technique=Exfiltration to Cloud Storage,Tactic=Exfiltration,Level=4,Alert=Rclone detected,Risk=100" groupRelation="or">
+				<OriginalFileName condition="contains any">rclone</OriginalFileName>
+				<Description condition="contains any">Rsync for cloud storage</Description>
+				<Product condition="contains any">rclone</Product>
+				<Company condition="contains any">rclone</Company>
+				<Image condition="contains any">\rclone</Image>
+			</Rule>
+			<Rule name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=4,Alert=S3browser detected,Risk=100" groupRelation="or">
+				<OriginalFileName condition="contains any">s3browser</OriginalFileName>
+				<Description condition="contains any">s3browser</Description>
+				<Product condition="contains any">s3browser</Product>
+				<Image condition="contains any">s3browser</Image>
+			</Rule>
+			<Rule name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=4,Alert=FTP exfiltration detected,Risk=100" groupRelation="or">
+				<CommandLine condition="contains any">add-ftp;.UploadFile(</CommandLine>
+				<Image condition="contains any">ftp.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1048,Tactic=Exfiltration,Technique=Exfiltration to Cloud Storage,Level=0,Desc=Webdav Share Mounted" groupRelation="and">
+				<Image condition="image">rundll32.exe</Image>
+				<CommandLine condition="contains all">davclnt.dll;DavSetCookie</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over C2 Channel-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Other Network Medium-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Physical Medium-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Web Service-->
+
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Transfer-->
+			<!--MITRE ATT&CK TECHNIQUE: Transfer Data to Cloud Account-->
+
+			<!--MITRE ATT&CK TACTIC: Impact-->
+			<Rule name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=Possible Ransomware Command Detected,Risk=100" groupRelation="and">
+				<Image condition="image">bcdedit.exe</Image>
+				<CommandLine condition="contains">safeboot</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=Possible Ransomware Command Detected,Risk=100" groupRelation="and">
+				<Image condition="image">bootcfg.exe</Image>
+				<CommandLine condition="contains">safeboot</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=Possible Ransomware Virtual Machine,Risk=60" groupRelation="and">
+				<CommandLine condition="contains any">-startvm;vrun.exe -vm</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Account Access Removal-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Destruction-->
+			<Rule name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Data Destruction with vssadmin Detected,Risk=100" groupRelation="and">
+				<Image condition="image">vssadmin.exe</Image>
+				<CommandLine condition="contains any">delete;resize</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Data Destruction with wmic shadowcopy delete Detected,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">wmic.exe</OriginalFileName>
+				<CommandLine condition="contains all">shadowcopy;delete</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Data Destruction with wbadmin Detected,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">wbadmin.exe</OriginalFileName>
+				<CommandLine condition="contains all">SYSTEMSTATEBACKUP;delete</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Data Destruction with wmic shadowstorage Detected,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">wmic.exe</OriginalFileName>
+				<CommandLine condition="contains">wmic shadowstorage SET MaxSpace=</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Destructive WMIC Commands Detected,Risk=100" groupRelation="and">
+				<OriginalFileName condition="contains">wmic.exe</OriginalFileName>
+				<CommandLine condition="contains any">cleareventlog;call disable;nteventlog where filename</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=0,Alert=Data Destruction with diskpart" groupRelation="and">
+				<OriginalFileName condition="contains">diskpart.exe</OriginalFileName>
+				<CommandLine condition="contains any">format;clean;delete;remove</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=0,Alert=Data Destruction with manage-bde.exe" groupRelation="and">
+				<OriginalFileName condition="contains">manage-bde.exe</OriginalFileName>
+				<CommandLine condition="contains any">changepin;changepassword;changekey;wipefreespace;lock;/on;-on;/off;-off;-add;/add;-pw;/pw</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=0,Alert=Data Destruction with manage-bde.wsf" groupRelation="and">
+				<CommandLine condition="contains">manage-bde.wsf</CommandLine>
+				<CommandLine condition="contains any">changepin;changepassword;changekey;wipefreespace;lock;/on;-on;/off;-off;-add;/add;-pw;/pw</CommandLine>
+			</Rule>
+			<CommandLine name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=3,Alert=Data Destruction with format" condition="begin with">format </CommandLine>
+			<CommandLine name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=3,Alert=Data Destruction with format" condition="begin with">format </CommandLine>
+			<CommandLine name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Data Destruction with bcdedit Detected,Risk=100" condition="contains">bootstatuspolicy ignoreallfailures</CommandLine>
+			<CommandLine name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Data Destruction with bcdedit Detected,Risk=100" condition="contains">recoveryenabled No</CommandLine>
+			<CommandLine name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Data Destruction with get-wmiobject Detected,Risk=100" condition="contains">Win32_Shadowcopy</CommandLine>
+			<CommandLine name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Data Destruction with sdelete Detected,Risk=100" condition="contains">sdelete</CommandLine>
+			<CommandLine name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Data Destruction with wbadmin Detected,Risk=100" condition="contains">delete catalog</CommandLine>
+			<CommandLine name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Data Destruction with wbadmin Detected,Risk=100" condition="contains">wbadmin delete catalog</CommandLine>
+			<CommandLine name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=0,Desc=Data Destruction with erase Detected,Risk=100" condition="contains">erase</CommandLine>
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">-nw -exec=</CommandLine><!-- vshadow -->
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">-p -nw</CommandLine><!-- vshadow -->
+			<Image name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Data Destruction with shred Detected,Risk=100" condition="contains">shred</Image>
+			<ParentImage name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=4,Alert=Diskshadow Execution,Risk=70" condition="contains">diskshadow</ParentImage>
+			<Rule name="Attack=T1485,Technique=Data Destruction,Tactic=Impact,Level=3,Alert=Command Line File Deletion,Risk=100" groupRelation="or">
+				<CommandLine condition="contains all"> del ; /f </CommandLine>
+				<CommandLine condition="contains all"> del ; -f </CommandLine>
+				<CommandLine condition="contains all"> rmdir ; /s ; /q </CommandLine>
+				<CommandLine condition="contains all"> rmdir ; -s ; -q </CommandLine>
+				<CommandLine condition="contains all"> rd ; /s ; /q </CommandLine>
+				<CommandLine condition="contains all"> rd ; -s ; -q </CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Data Encrypted for Impact-->
+			<CommandLine name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=3,Alert=Potential Ransomware indicator" condition="contains">usn deletejournal</CommandLine>
+			<!--MITRE ATT&CK TECHNIQUE: Data Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: Defacement-->
+			<!--MITRE ATT&CK TECHNIQUE: Disk Wipe-->
+			<Rule name="Attack=T1107,Technique=File Deletion,Tactic=Defense Evasion,Level=3,Alert=FSUtil USN Journal Deletion,Risk=60" groupRelation="and">
+				<Image condition="image">fsutil.exe</Image>
+				<CommandLine condition="contains">deletejournal</CommandLine>
+				<CommandLine condition="contains">usn</CommandLine>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Endpoint Denial of Service-->
+			<!--MITRE ATT&CK TECHNIQUE: Firmware Corruption-->
+			<!--MITRE ATT&CK TECHNIQUE: Inhibit System Recovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Denial of Service-->
+			<!--MITRE ATT&CK TECHNIQUE: Resource Hijacking-->
+			<!--MITRE ATT&CK TECHNIQUE: Service Stop-->
+			<!--MITRE ATT&CK TECHNIQUE: System Shutdown/Reboot-->
+			<!--Malicious Keywords Credits: Sean Metcalf (source), Florian Roth (rule)-->
+			<CommandLine name="Attack=T1059,Technique=Command-Line Interface,Tactic=Execution,Level=4,Alert=Malicious Keywords from Exploitation Frameworks" condition="contains any">AdjustTokenPrivileges;IMAGE_NT_OPTIONAL_HDR64_MAGIC;LSA_UNICODE_STRING;Management.Automation.RuntimeException;Metasploit;Microsoft.Win32.UnsafeNativeMethods;Mimikatz;MiniDumpWriteDump;Net.Sockets.SocketFlags;PAGE_EXECUTE_READ;ReadProcessMemory.Invoke;Reflection.Assembly;Runtime.InteropServices;SECURITY_DELEGATION;SE_PRIVILEGE_ENABLED;System.Runtime.InteropServices;System.Security.Cryptography;TOKEN_ADJUST_PRIVILEGES;TOKEN_ALL_ACCESS;TOKEN_ASSIGN_PRIMARY;TOKEN_DUPLICATE;TOKEN_ELEVATION;TOKEN_IMPERSONATE;TOKEN_INFORMATION_CLASS;TOKEN_PRIVILEGES;TOKEN_QUERY;powerkatz</CommandLine>
+			<!--Crypto Currency Miner Detections-->
+			<Rule name="Level=4,Alert=Crypto Currency Miner Detected,Attack=T1496,Technique=Resource Hijacking,Tactic=Impact" groupRelation="or">
+				<CommandLine condition="contains any">ahashpool;blazepool;blockmasters;blockmasterscoins;ccminer;cgminer;coinhive;hashrefinery;minergate;miningpoolhubcoins;nicehash;poolname;poolpassword;poolurl;rainbowminer;sgminer;stratum+tcp;xmrMiner;xmrig;yiimp;zergpool;zergpoolcoins;zpool</CommandLine>
+				<Description condition="contains any">CPU miner;GPU miner;Lime Miner;XMRig CPU miner; miner</Description>
+			</Rule>
+			<!--Malware Hashes-->
+			<Rule name="Attack=T1195,Technique=Supply Chain Compromise,Tactic=Initial Access,Level=4,Alert=Solarwinds/FireEye sunburst hashes,Risk=100" groupRelation="and">
+				<Hashes condition="contains any">b91ce2fa41029f6955bff20079468448;02af7cec58b9a5da1c542b5a32151ba1;2c4a910a1299cdae2a4e55988a2f102e;846e27a652a5e1bfbd0ddd38a16dc865;4f2eb62fa529c0283b28d05ddd311fae;56ceb6d0011d87b6e4d7023d7ef85676</Hashes>
+			</Rule>
+			<Hashes condition="end with" name="Level=0,Desc=plink.exe 64bit imphash matched,Risk=40">87AECF008D87EC86EC8B00A2394B3E6C</Hashes>
+			<Hashes condition="end with" name="Level=0,Desc=plunk.exe 32bit imphash matched,Risk=40">FB3F0D0DE8B80EA8CFAB2A025EC6B833</Hashes>
+			<Hashes condition="end with" name="Level=0,Desc=putty.exe 64bit imphash matched,Risk=40">F4067FBF7FFF6945D0BB485B727B39AA</Hashes>
+			<Hashes name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=4,Alert=Generic APT Hash Detection,Risk=100" condition="contains any">4a069c1abe5aca148d5a8fdabc26751e;c96ed56bf7ee85a4398cc43a98b4db86d3da311c619f17c8540ae424ca6546e1;304772c80b157a916c7041f2f15939fb;291ff87948e45914424cec9510c297da;a4b42c2c95d1f2ff12171a01c86cd64f;98908ce6f80ecc48628c8d2bf5b2a50c;849a2b0dc80aeca3d175c139efe5221c;807d86da63f0db1fc746d1f0b05bc357;322cb39bc049aa69136925137906d855;86A4CAC227078B9C95C560C8F0370BF0;36dd195269979e01a29e37c488928497;7d9d29c1c03461608bcab930fef2f568;eac3e3ece94bc84e922ec077efb15edd;b4abe604916c04fe3dd8b9cb3d501d3f;88777aacd5f16599547926a4c9202862;128CECC59C91C0D0574BC1075FE7CB40;17a36ac3e31f3a18936552aff2c80249;0f49621b06f2cdaac8850c6e9581a594;3d129263f6a48647f103a04446fb0c2f;71345b139166482acaa568ac8816c7bc;1b60021baedc3f9201bcdb40e9b87f62;5E022694C0DBD1FBBC263D608E577949;cd4b9d0f2d1c0468750855f0ed352c1ed6d4f512d66e0e44ce308688235295b5;b017b9fc2484ce0a5629ff1fed15bca9f62f942eafbb74da6a40f40337187b04;2010f38ef300be4349e7bc287e720b1ecec678cacbf0ea0556bcf765f6e073ec;6a251ed6a2c6a0a2be11f2a945ec68c814d27e2b6ef445f4b2c7a779620baa11;5b102bf4d997688268bab45336cead7cdf188eb0d6355764e53b4f62e1cdf30c;37cd353621b0f4fc6981b50071c94f01;daf2da52475fd8981b19ec3c321a983c;afcdf79be1557326c854b6e20cb900a7;2f40abbb4f78e77745f0e657a19903fc953cc664;37b4496e650b3994312c838435013560b3ca8571;478dc5a5f934c62a9246f7d1fc275868f568bc07;1a2ab4df156ccd685f795baee7df49f8e701f271d3e5676b507112e30ce03c42;2c1d3d0a9c6f76726994b88589219cb8d9c39dd9924bc8d2d02bf41d955fe326;5c776a33568f4c16fee7140c249c0d2b1e0798a96c7a01bfd2d5684e58c9bb32;5fc4b0076eac7aa7815302b0c3158076e3569086c4c6aa2f71cd258238440d14;08c34c6ac9186b61d9f29a77ef5e618067e0bc9fe85cab1ad25dc6049c376949;758598370c3b84c6fbb452e3d7119f700f970ed566171e879d3cb41102154272;bef59b9a3e00a14956e0cd4a1f3e7524448cbe5d3cc1295d95a15b83a3579c59;c96ed56bf7ee85a4398cc43a98b4db86d3da311c619f17c8540ae424ca6546e1;c96ed56bf7ee85a4398cc43a98b4db86d3da311c619f17c8540ae424ca6546e1;e8542c07b2af63ee7e72ce5d97d91036c5da56e2b091aa2afe737b224305d230;0ac48cfa2ff8351365e99c1d26e082ad;0e9afd3a870906ebf34a0b66d8b07435;1aadf739782afcae6d1c3e4d1f315cbd;2a6f7ec77ab6bd4297e7b15ae06e2e61;3a771efb7ba2cd0df247ab570e1408b2;3d75c72144d873b3c1c4977fbafe9184;3dfebce4703f30eed713d795b90538b5;3ffd2915d285ad748202469d4a04e1f5;4e39620afca6f60bb30e031ddc5a4330;6cfd131fef548fcd60fbcdb59317df8e;7bcd736a2394fc49f3e27b3987cce640;7bfba2c69bed6b160261bdbf2b826401;7bfbd72441e1f2ed48fbc0f33be00f24;7c733607a0932b1b9a9e27cd6ab55fe0;7d5265e814843b24fcb3787768129040;08e82dc7bae524884b7dc2134942aadb;8da15a97eaf69ff7ee184fc446f19cf1;9ad6fa6fdedb2df8055b3d30bd6f64f1;9c115e9a81d25f9d88e7aaa4313d9a8f;16ab79fb2fd92db0b1f38bedb2f02ed8;21feb6aa15e02bb0cddbd544605aabad;21feb6aa15e02bb0cddbd544605aabad;22d142f11cf2a30ea4953e1fffb0fa7e;36db24006e2b492cafb75f2663f241b2;51a7068640af42c3a7c1b94f1c11ab9d;69a19abf5ba56ee07cdd3425b07cf8bf;72dc98449b45a7f1ccdef27d51e31e91;77a745b07d9c453650dd7f683b02b3ed;80c37e062aa4c94697f287352acf2e9d;92f8e3f0f1f7cc49fad797a62a169acd;235d427f94630575a4ea4bff180ecf5d;320b2f1d9551b5d1df4fb19bd9ab253a;490a140093b5870a47edc29f33542fd2;520ee02668a1c7b7c262708e12b1ba6b;649ef1dd4a5411d3afcf108d57ff87af;684eca6b62d69ce899a3ec3bb04d0a5b;815f1f8a7bc1e6f94cb5c416e381a110;0969b2b399a8d4cd2d751824d0d842b4;2317d65da4639f4246de200650a70753;04078ef95a70a04e95bda06cc7bec3fa;8035a8a143765551ca7db4bc5efb5dfd;8403a28e0bffa9cc085e7b662d0d5412;9003cfaac523e94d5479dc6a10575e60;9793afcea43110610757bd3b800de517;27612cb03c89158225ca201721ea1aad;44619a88a6cff63523163c6a4cf375dd;061089d8cb0ca58e660ce2e433a689b3;81229c1e272218eeda14892fa8425883;84730a6e426fbd3cf6b821c59674c8a0;533340c54bd25256873b3dca34d7f74e;57314359df11ffdf476f809671ec0275;99828721ac1a0e32e4582c3f615d6e57;412956675fbc3f8c51f438c1abc100eb;5985087678414143d33ffc6e8863b887;a43d3b31575846fa4c3992b4143a06da;a571660c9cf1696a2f4689b2007a12c7;b4e67706103c3b8ee148394ebee3f268;b9c208ea8115232bfd9ec2c62f32d6b8;b9cf4301b7b186a75e82a04e87b30fe4;b72737b464e50aa3664321e8e001ff32;bfe3f6a79cad5b9c642bb56f8037c43b;c0e72eb4c9f897410c795c1b360090ef;c1e7850da5604e081b9647b58248d7e8;c3e255888211d74cc6e3fb66b69bbffb;cacaa3bf3b2801956318251db5e90f3c;cdb303f61a47720c7a8c5086e6b2a743;ce8ce92fb6565181572dce00d69c24f8;d8f1356bebda9e77f480a6a60eab36bb;d9e9f22988d43d73d79db6ee178d70a4;d5377dc1821c935302c065ad8432c0d2;df91b86189adb0a11c47ce2405878fa1;e17bd40f5b5005f4a0c61f9e79a9d8c2;f559c87b4a14a4be1bd84df6553aaf56;fc53f2cd780cd3a01a4299b8445f8511;ffc7305cb24c1955f9625e525d58aeee</Hashes>
+			<Hashes name="Attack=T1353,Technique=Post Compromise Tool Development,Tactic=Build Capabilities,Level=4,Alert=Windows Credential Editor Detection,Risk=70" condition="contains any">e96a73c7bf33a464c510ede582318bf2;a53a02b997935fd8eedcb5f7abab9b9f</Hashes>
+			<Hashes name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=Ransomware Hash Detection,Risk=100" condition="contains any">d326e629a90e78825645963b35e53a6a;c579341f86f7e962719c7113943bb6e4;dc5733c013378fa418d13773f5bfe6f1;b8fcd4a3902064907fb19e0da3ca7aed72a7e6d1f94d971d1ee7a4d3af6a800d;965884f19026913b2c57b8cd4a86455a61383de01dabb69c557f45bb848f6c26;4a069c1abe5aca148d5a8fdabc26751e;dc7e564809d6c2a2f3457c3c9b91f22b;FE2CA1BE3BDA2A757036A89E54CC02DB;5470f0644589685000154cb7d3f60280acb16e39ca961cce2c016078b303bc1b</Hashes>
+			<Hashes name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=Ursniff Bank Malware,Risk=100" condition="contains">53841a0c6a3ff92976db08bfdf95e083</Hashes>
+			<!--UEBA Activities-->
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Zoom: passwordless meeting Start,Risk=30" groupRelation="and">
+				<CommandLine condition="contains">zoommtg</CommandLine>
+				<CommandLine condition="excludes">pwd=</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Zoom: Video and Audio Session Start" groupRelation="and">
+				<CommandLine condition="contains">zoommtg</CommandLine>
+				<CommandLine condition="contains">zc=0</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Zoom: Screen Share,Risk=70" groupRelation="and">
+				<CommandLine condition="contains">zoommtg</CommandLine>
+				<CommandLine condition="contains">zc=1</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Microsoft Teams URL clicked" groupRelation="and">
+				<CommandLine condition="contains">msteams:</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Webex URL clicked" groupRelation="and">
+				<CommandLine condition="contains">wbx:</CommandLine>
+			</Rule>
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Executed files within Downloads,Risk=30" groupRelation="and">
+				<Image condition="contains">C:\Users\</Image>
+				<Image condition="contains">\Downloads\</Image>
+			</Rule>
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Executed files on Desktop,Risk=10" groupRelation="and">
+				<Image condition="contains">C:\Users\</Image>
+				<Image condition="contains">\Desktop\</Image>
+			</Rule>
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Linux tools installed on windows,Risk=30" groupRelation="and">
+				<Image condition="contains any">\awk.exe;\sed.exe</Image>
+			</Rule>
+			<CommandLine condition="contains">listena</CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=3,Alert=LOLBins" condition="contains any">-s -n -u -i:http:</CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=3,Alert=LOLBins" condition="contains any">/s /n /u /i:http:</CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Interesting Command Line Events" condition="begin with">assoc </CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Interesting Command Line Events" condition="begin with">del </CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Interesting Command Line Events" condition="begin with">expand </CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Interesting Command Line Events" condition="begin with">md </CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Interesting Command Line Events" condition="begin with">move </CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Interesting Command Line Events" condition="begin with">rd </CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Interesting Command Line Events" condition="begin with">ren </CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Interesting Command Line Events" condition="begin with">set </CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Interesting Command Line Events" condition="begin with">setx </CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Interesting Command Line Events" condition="contains any">bginfo.bgi /popup /nolicprompt;bginfo.bgi -popup -nolicprompt</CommandLine>
+			<CommandLine name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Interesting Command Line Events" condition="image">find.exe</CommandLine>
+			<CommandLine name="Attack=T1595,Technique=Hacking,Tactic=Execution,Level=3,Alert=FireEye/Fin6 Hacking tools" condition="contains">grabff</CommandLine>
+			<CommandLine name="Attack=T1595,Technique=Hacking,Tactic=Execution,Level=3,Alert=FireEye/Fin6 Hacking tools" condition="contains">routerscan</CommandLine>
+			<CommandLine name="Attack=T1059.006,Technique=Command and Scripting Interpreter: Python,Tactic=Execution,Level=3,Alert=Hacking with python,Risk=70" condition="contains">pythonEngine.Execute</CommandLine>
+			<CommandLine name="Attack=T1059.006,Technique=Command and Scripting Interpreter: Python,Tactic=Execution,Level=4,Alert=Hacking with session hijacking,Risk=100" condition="contains">sesshijack</CommandLine>
+			<CommandLine name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=File Protocol Handler Execution" condition="contains">file://</CommandLine>
+			<Description name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">HTML Application host</Description>
+			<Description name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">Manager Profile Installer</Description>
+			<Description name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Microsoft Application Virtualization Injector</Description>
+			<Description name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Application Compatibility Database Installer</Description>
+			<Image name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=LOLbin" condition="image">popd.exe</Image>
+			<Image name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=LOLbin" condition="image">pushd.exe</Image>
+			<Image name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=LOLbin" condition="image">subst.exe</Image>
+			<Image name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=detect aliases" condition="image">doskey.exe</Image>
+			<Image name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=detect cls in batch scripts" condition="image">cls.exe</Image>
+			<Image name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=UNC\Device Launches - Image begins with \,Risk=10" condition="begin with">\</Image> 
+			<ParentCommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\system32\svchost.exe -k iissvcs</ParentCommandLine>
+			<ParentImage name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=UNC\Device Launches - Parent Image begins with \,Risk=10" condition="begin with">\</ParentImage> 
+			<ParentImage name="Attack=T1059,Level=0,Desc=Process Spawned from Acrobat" condition="image">acrobat.exe</ParentImage>
+			<ParentImage name="Attack=T1059,Level=0,Desc=Process Spawned from Adobe Reader" condition="image">acrord32.exe</ParentImage>
+			<ParentImage name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">java.exe</ParentImage>
+			<ParentImage name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">javaw.exe</ParentImage>
+			<!--Detect Output Redirection-->
+			<!-- Disabled for now: Reason: Overrides other detections, waiting on Sysmon multiple rule firing
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">2></CommandLine>
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">&gt;</CommandLine>
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">&lt;</CommandLine>
+			-->
+			<!--Detect Multiple Commands-->
+			<Rule  name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">C:\Windows\system32\svchost.exe</Image>
+			</Rule>
+			<Image name="Attack=T1222,Technique=File Permissions Modification,Tactic=Defense Evasion,Level=0,Desc=Permission Modifications with icacls or cacls" condition="contains">cacls</Image>
+			<Image name="Attack=T1222,Technique=File Permissions Modification,Tactic=Defense Evasion,Level=0,Desc=Ownership Permission Modifications with takeown" condition="contains">takeown</Image>
+			<CommandLine condition="contains" name="Level=0,Desc=Suspicious Cmdline: MsAccess MACRO Exec">/x Macro</CommandLine>
+			<Rule  name="Level=3,Desc=Suspicious pipe via commandline" groupRelation="and">
+				<CommandLine condition="contains">\pipe\</CommandLine>
+				<CommandLine condition="excludes">&gt;</CommandLine> <!--Excludes piping to pipe for cobalt strike detection-->
+			</Rule>
+			<CommandLine condition="contains" name="Level=0,Desc=Suspicious Cmdline: RDP Port">/noprofile</CommandLine>
+			<CommandLine condition="contains" name="Level=0,Desc=Suspicious Cmdline: Schtasks">/sc ONEVENT</CommandLine>
+			<CommandLine name="Level=3,Alert=Execution run from \\VBOXSVR share" condition="contains">\\VBOXSVR</CommandLine>
+			<CommandLine name="Level=3,Alert=interactive command to slow output" condition="contains">| more</CommandLine>
+			<CommandLine name="Level=3,Alert=interactive command to slow output" condition="contains">|more</CommandLine>
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\\tsclient</CommandLine>
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">%PROCESSOR_ARCHITECTURE%</CommandLine>
+			<CommandLine name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">sysnative</CommandLine>
+			<Description name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">AutoIt</Description>
+			<Description name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Microsoft Filter Loader</Description> 
+			<Image name="Level=3,Alert=interactive command to slow output" condition="is">more.com</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">:\Windows\Microsoft.NET\</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">acrord32.exe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="image">gpupdate.exe</Image>
+			<ParentImage name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">:\Windows\Microsoft.NET\</ParentImage>
+			<!-- Log other command line events, this sometimes conflicts with rules, add to exclusions as necessary-->
+			<!-- <ParentCommandLine name="Information=Uncategorized Events" condition="contains any">/;\;-;unknown;</ParentCommandLine>-->
+		</ProcessCreate>
+	</RuleGroup>
+	<RuleGroup name="RG=Process Create Exclude Group" groupRelation="or">
+		<ProcessCreate onmatch="exclude">
+			<Rule name="exclude werfault from wmi" groupRelation="and">
+				<Image condition="image">C:\Windows\System32\WerFault.exe</Image>
+				<ParentImage condition="image">C:\Windows\System32\wbem\WmiPrvSE.exe</ParentImage>
+			</Rule>
+		</ProcessCreate>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 2 : FILE CREATION TIME RETROACTIVELY CHANGED IN THE FILESYSTEM [FileCreateTime]-->
+	<RuleGroup name="RG=FileCreateTime Include Group" groupRelation="or">
+		<FileCreateTime onmatch="include">
+			<Image name="Attack=T1070.006,Technique=Timestomp,Tactic=Defense Evasion" condition="begin with">C:\Users</Image>
+			<Image name="Attack=T1070.006,Technique=Timestomp,Tactic=Defense Evasion" condition="begin with">C:\ProgramData</Image>
+			<Image name="Attack=T1070.006,Technique=Timestomp,Tactic=Defense Evasion" condition="contains">\Temp\</Image>
+			<Image name="Attack=T1070.006,Technique=Timestomp,Tactic=Defense Evasion" condition="contains">\tmp\</Image>
+			<Image name="Attack=T1070.006,Technique=Timestomp,Tactic=Defense Evasion" condition="contains">\drivers\</Image>
+			<Image name="Attack=T1070.006,Technique=Timestomp,Tactic=Defense Evasion" condition="contains">\Download</Image>
+		</FileCreateTime>
+	</RuleGroup>
+	<RuleGroup name="RG=FileCreateTime Exclude Group" groupRelation="or">
+		<FileCreateTime onmatch="exclude">
+			<Image condition="image">C:\Windows\system32\backgroundTaskHost.exe</Image>
+			<Image condition="image">TrustedInstaller.exe</Image>
+			<Image condition="image">OneDrive.exe</Image>
+			<Image condition="image">vivaldi.exe</Image>
+			<Image condition="image">chrome.exe</Image>
+			<Image condition="image">C:\WINDOWS\system32\backgroundTaskHost.exe</Image>
+			<Image condition="contains">setup</Image>
+			<Image condition="end with">AppData\Local\Microsoft\Teams\current\Teams.exe</Image>
+			<Image condition="end with">\AppData\Local\Microsoft\Edge SxS\Application\msedge.exe</Image>
+		</FileCreateTime>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 3 : NETWORK CONNECTION INITIATED [NetworkConnect]-->
+	<RuleGroup name="RG=NetworkConnect Include Group" groupRelation="or">
+		<NetworkConnect onmatch="include">
+			<!--MITRE ATT&CK TACTIC: Reconnaissance-->
+			<!--MITRE ATT&CK TECHNIQUE: Active Scanning-->
+			<DestinationHostname name="Attack=T1595,Technique=Network Service Scanning/Reconnaissance,Tactic=Discovery,Level=0,Desc=Census Network Connection,Risk=40" condition="contains">census</DestinationHostname>
+			<DestinationHostname name="Attack=T1595,Technique=Network Service Scanning/Reconnaissance,Tactic=Discovery,Level=0,Desc=ResearchScan Network Connection,Risk=70" condition="contains">researchscan</DestinationHostname>
+			<DestinationHostname name="Attack=T1595,Technique=Network Service Scanning/Reconnaissance,Tactic=Discovery,Level=0,Desc=Scanhub Network Connection,Risk=70" condition="contains">scanhub</DestinationHostname>
+			<DestinationHostname name="Attack=T1595,Technique=Network Service Scanning/Reconnaissance,Tactic=Discovery,Level=0,Desc=Shadow Network Connection,Risk=50" condition="contains">shadow</DestinationHostname>
+			<DestinationHostname name="Attack=T1595,Technique=Network Service Scanning/Reconnaissance,Tactic=Discovery,Level=0,Desc=Shodan Network Connection,Risk=50" condition="contains">shodan</DestinationHostname>
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Host Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Identity Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Network Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Org Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Phishing for Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Closed Sources-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Open Technical Databases-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Open Websites/Domains-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Victim-Owned Websites-->
+
+			<!--MITRE ATT&CK TACTIC: Resource Development-->
+			<!--MITRE ATT&CK TECHNIQUE: Acquire Infrastructure-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Infrastructure-->
+			<!--MITRE ATT&CK TECHNIQUE: Develop Capabilities-->
+			<!--MITRE ATT&CK TECHNIQUE: Establish Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Obtain Capabilities-->
+			<!--MITRE ATT&CK TECHNIQUE: Stage Capabilities-->
+
+			<!--MITRE ATT&CK TACTIC: Initial Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Drive-by Compromise-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploit Public-Facing Application-->
+			<!--MITRE ATT&CK TECHNIQUE: External Remote Services-->
+			<!--MITRE ATT&CK TECHNIQUE: Hardware Additions-->
+			<!--MITRE ATT&CK TECHNIQUE: Phishing-->
+			<!--MITRE ATT&CK TECHNIQUE: Replication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Supply Chain Compromise-->
+			<!--MITRE ATT&CK TECHNIQUE: Trusted Relationship-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts -->
+			
+			<!--MITRE ATT&CK TACTIC: Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter-->
+			<Rule name="Attack=T1059,Technique=Visual Basic,Tactic=Execution,Level=4,Alert=WSCRIPT Network connection,Risk=80" groupRelation="and">
+				<Image condition="image">wscript.exe</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Container Administration Command-->
+			<!--MITRE ATT&CK TECHNIQUE: Deploy Container-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Client Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Inter-Process Communication-->
+			<!--MITRE ATT&CK TECHNIQUE: Native API-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<Image name="Attack=T1053.005,Technique=Scheduled Task,Tactic=Execution/Persistence/Privilege Escalation,Level=4,Alert=AT.EXE Task Scheduler Network Connection,Risk=30" condition="image">at.exe</Image>
+			<Image name="Attack=T1053.005,Technique=Scheduled Task,Tactic=Execution/Persistence/Privilege Escalation,Level=4,Alert=SCHTasks.exe Task Scheduler Network Connection,Risk=30" condition="image">schtasks.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Shared Modules-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Deployment Tools-->
+			<!--MITRE ATT&CK TECHNIQUE: System Services-->
+			<!--MITRE ATT&CK TECHNIQUE: User Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Windows Management Instrumentation-->
+
+			<!--MITRE ATT&CK TACTIC: Persistence-->
+			<!--MITRE ATT&CK TECHNIQUE: Account Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: BITS Jobs-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Autostart Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Initialization Scripts-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Extensions-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Client Software Binary-->
+			<!--MITRE ATT&CK TECHNIQUE: Create Account-->
+			<!--MITRE ATT&CK TECHNIQUE: Create or Modify System Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Event Triggered Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: External Remote Services-->
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<!--MITRE ATT&CK TECHNIQUE: Implant Internal Image-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Office Application Startup-->
+			<!--MITRE ATT&CK TECHNIQUE: Pre-OS Boot-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<!--MITRE ATT&CK TECHNIQUE: Server Software Component-->
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+
+			<!--MITRE ATT&CK TACTIC: Privilege Escalation-->
+			<!--MITRE ATT&CK TECHNIQUE: Abuse Elevation Control Mechanism-->
+			<!--MITRE ATT&CK TECHNIQUE: Access Token Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Autostart Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Initialization Scripts-->
+			<!--MITRE ATT&CK TECHNIQUE: Create or Modify System Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Policy Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Escape to Host-->
+			<!--MITRE ATT&CK TECHNIQUE: Event Triggered Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Privilege Escalation-->
+
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Injection-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+
+			<!--MITRE ATT&CK TACTIC: Defense Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Abuse Elevation Control Mechanism-->
+			<!--MITRE ATT&CK TECHNIQUE: Access Token Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: BITS Jobs-->
+			<!--MITRE ATT&CK TECHNIQUE: Build Image on Host-->
+			<!--MITRE ATT&CK TECHNIQUE: Debugger Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Deobfuscate/Decode Files or Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Deploy Container-->
+			<!--MITRE ATT&CK TECHNIQUE: Direct Volume Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Policy Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Execution Guardrails-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Defense Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: File and Directory Permissions Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Hide Artifacts-->
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<!--MITRE ATT&CK TECHNIQUE: Impair Defenses-->
+			<!--MITRE ATT&CK TECHNIQUE: Indicator Removal on Host-->
+			<!--MITRE ATT&CK TECHNIQUE: Indirect Command Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Masquerading-->
+			<Rule name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=0,Desc=Temp file location network connection,Risk=30" groupRelation="and">
+				<Image condition="contains">\temp\</Image> <!--Network Connection in Temp Directories-->
+				<DestinationIp condition="excludes any">127.0.0.1</DestinationIp>		
+			</Rule>
+			<Rule name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network Connection from wwwroot folder: Possible webshell,Risk=100" groupRelation="and">
+				<Image condition="contains">\wwwroot\</Image>
+			</Rule>
+			<Image name="Level=4,Alert=Network connection in addins" condition="contains">\Windows\addins\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network Connection from Windows\repair Folder,Risk=70" condition="begin with">C:\Windows\repair\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network Connection from htdocs folder,Risk=70" condition="contains">\htdocs\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network Connection from systemprofile Folder,Risk=30" condition="begin with">C:\Windows\system32\config\systemprofile\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network connection from Intel logs,Risk=100" condition="begin with">C:\Intel\Logs\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network connection from Windows\Addins Folder,Risk=70" condition="begin with">C:\Windows\addins\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network connection from Windows\security Folder,Risk=100" condition="begin with">C:\Windows\security\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network connection from windows help folder,Risk=70" condition="begin with">C:\Windows\Help\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network connection in Recycle Bin,Level=4,Alert=Suspicious network connection from Recycle bin,Risk=100" condition="contains">$RECYCLE.BIN</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network connection in Windows Debug folder,Risk=100" condition="begin with">C:\Windows\Debug\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Network connection in Windows Font folder,Risk=100" condition="begin with">C:\Windows\Fonts\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Perflogs unusual network connection,Risk=70" condition="begin with">C:\PerfLogs\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=4,Alert=Unusual network connection from Recycle bin,Risk=100" condition="contains">:\$Recycle.bin\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=0,Desc=Network Connection from Default User folder,Risk=30" condition="contains">:\Users\Default\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=0,Desc=Network Connection from NetworkService User folder,Risk=30" condition="begin with">C:\Users\NetworkService\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=0,Desc=Network connection from Public User folder,Risk=30" condition="begin with">C:\Users\Public\</Image>
+			<Image name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Level=0,Desc=Network connection within Media Folder,Risk=30" condition="begin with">C:\Windows\Media\</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Windows\IME\</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\ProgramData</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Cloud Compute Infrastructure-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Registry-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify System Image-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Boundary Bridging-->
+			<!--MITRE ATT&CK TECHNIQUE: Obfuscated Files or Information-->
+			<Rule name="Attack=T1027.004,Tactic=Defense Evasion,Technique=Compile After Delivery,Level=4,Alert=CSC Network Conections" groupRelation="and">
+				<Image condition="image">CSC.exe</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Plist File Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Pre-OS Boot-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Injection-->
+			<!--MITRE ATT&CK TECHNIQUE: Reflective Code Loading-->
+			<!--MITRE ATT&CK TECHNIQUE: Rogue Domain Controller-->
+			<!--MITRE ATT&CK TECHNIQUE: Rootkit-->
+			<!--MITRE ATT&CK TECHNIQUE: Subvert Trust Controls-->
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution-->
+			<Image name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Defense Evasion,Level=0,Desc=infDefaultInstall Network Connection" condition="image">infDefaultInstall.exe</Image>
+			<Image name="Attack=T1218,Technique=Control Panel,Tactic=Defense Evasion,Level=0,Desc=Control Panel network connection" condition="image">SyncAppvPublishingServer.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Regsvr32-->
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Installutil-->
+			<Image name="Attack=T1218.004,Technique=InstallUtil,Tactic=Defense Evasion,Level=4,Alert=InstallUtil network connection" condition="image">InstallUtil.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Msiexec-->
+			<Image name="Attack=T1218.007,Technique=MSIExec,Tactic=Defense Evasion,Level=4,Alert=MSIExec Network connection,Risk=70" condition="image">msiexec.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Regsvcs/regasm-->
+			<Rule name="Attack=T1218,Technique=Signed Binary Proxy Execution,Tactic=Execution,Level=4,Alert=RegAsm shellcode C2 connection" groupRelation="and">
+				<Image condition="contains any">regasm.exe;regsvcs.exe</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Mavinject-->
+			<Image name="Attack=T1218.013,Technique=Signed Binary Proxy Execution: Mavinject,Tactic=Execution,Level=4,Alert=Mavinject detected,Risk=80" condition="image">Mavinject.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: System Script Proxy Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Template Injection-->
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Trusted Developer Utilities Proxy Execution-->
+			<Rule name="Attack=T1127,Tactic=Defense Evasion,Technique=Signed Binary Proxy Execution,Level=4,Alert=MSBuild Network Conections" groupRelation="and">
+				<Image condition="image">msbuild.exe</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Unused/Unsupported Cloud Regions-->
+			<!--MITRE ATT&CK TECHNIQUE: Use Alternate Authentication Material-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Virtualization/Sandbox Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Weaken Encryption-->
+			<!--MITRE ATT&CK TECHNIQUE: XSL Script Processing-->
+
+			<!--MITRE ATT&CK TACTIC: Credential Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Adversary-in-the-Middle-->
+			<!--MITRE ATT&CK TECHNIQUE: Brute Force-->
+			<!--MITRE ATT&CK TECHNIQUE: Credentials from Password Stores-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Credential Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Forced Authentication-->
+			<!--MITRE ATT&CK TECHNIQUE: Forge Web Credentials-->
+			<!--MITRE ATT&CK TECHNIQUE: Input Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Factor Authentication Interception-->
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Factor Authentication Request Generation-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Sniffing-->
+			<!--MITRE ATT&CK TECHNIQUE: OS Credential Dumping-->
+			<!--MITRE ATT&CK TECHNIQUE: Steal Application Access Token-->
+			<!--MITRE ATT&CK TECHNIQUE: Steal or Forge Kerberos Tickets-->
+			<!--MITRE ATT&CK TECHNIQUE: Steal Web Session Cookie-->
+			<!--MITRE ATT&CK TECHNIQUE: Unsecured Credentials-->
+
+			<!--MITRE ATT&CK TACTIC: Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Account Discovery -->
+			<!--MITRE ATT&CK TECHNIQUE: Application Window Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Bookmark Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Infrastructure Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Service Dashboard-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Storage Object Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Container and Resource Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Debugger Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Trust Discovery-->
+			<Image name="Attack=T1482,Technique=Domain Trust Discovery,Tactic=Discovery,Level=0,Desc=DSQuery network connection" condition="image">dsquery.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: File and Directory Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Group Policy Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Share Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Sniffing-->
+			<!--MITRE ATT&CK TECHNIQUE: Password Policy Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Peripheral Device Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Permission Groups Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Query Registry-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote System Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Discovery-->
+			<Image name="Attack=T1518,Technique=Software Discovery,Tactic=Discovery,Level=0,Desc=DriverQuery Network Connection" condition="image">driverquery.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: System Information Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Location Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Network Configuration Discovery-->
+			<Image name="Attack=T1016,Technique=System Network Configuration Discovery,Tactic=Discovery,Level=4,Alert=NBTSTAT Query,Risk=30" condition="contains">nbtstat</Image>
+			<!--MITRE ATT&CK TECHNIQUE: System Network Connections Discovery-->
+			<Image name="Attack=T1021,Technique=System Network Configuration Discovery,Tactic=Discovery,Level=0,Desc=net.exe nework connection,Risk=30" condition="image">net.exe</Image>
+			<Image name="Attack=T1021,Technique=System Network Configuration Discovery,Tactic=Discovery,Level=0,Desc=net.exe nework connection,Risk=30" condition="image">net1.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: System Owner/User Discovery-->
+			<Image name="Attack=T1033,Technique=System Owner/User Discovery,Tactic=Discovery,Level=2,Alert=QWinsta User enumeration,Risk=30" condition="image">qwinsta.exe</Image>
+			<Image name="Attack=T1033,Technique=System Owner/User Discovery,Tactic=Discovery,Level=3,Alert=RWinsta Forced User Logoff,Risk=30" condition="image">rwinsta.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: System Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Time Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Virtualization/Sandbox Evasion-->
+
+			<!--MITRE ATT&CK TACTIC: Lateral Movement-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation of Remote Services-->
+			<!--MITRE ATT&CK TECHNIQUE: Internal Spearphishing-->
+			<!--MITRE ATT&CK TECHNIQUE: Lateral Tool Transfer-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote Service Session Hijacking-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote Services-->
+			<Rule name="Attack=T1021.001,Tactic=Lateral Movement,Technique=Remote Desktop Protocol,Level=3,Alert=Suspicious RDP Connection 3389,Risk=70" groupRelation="and">
+				<Initiated>true</Initiated>
+				<DestinationPort condition="is">3389</DestinationPort>
+				<Image condition="excludes">AutomationManager.ScriptRunner64.exe</Image>
+				<Image condition="excludes">C:\Program Files (x86)\VMware\VMware Remote Console\vmrc.exe</Image>
+				<Image condition="excludes">C:\Program Files\VMware\VMware Remote Console\vmrc.exe</Image>
+				<Image condition="excludes">C:\Program Files\WindowsApps\Microsoft.RemoteDesktop_</Image>
+				<Image condition="excludes">CtxLicUsageRecorder.exe</Image>
+				<Image condition="excludes">FSAssessment.exe</Image>
+				<Image condition="excludes">FSDiscovery.exe</Image>
+				<Image condition="excludes">MobaRTE.exe</Image>
+				<Image condition="excludes">RDCMan.exe</Image>
+				<Image condition="excludes">RSSensor.exe</Image>
+				<Image condition="excludes">RTS2App.exe</Image>
+				<Image condition="excludes">RTSApp.exe</Image>
+				<Image condition="excludes">RemoteDesktopManager64.exe</Image>
+				<Image condition="excludes">RemoteDesktopManager.exe</Image>
+				<Image condition="excludes">RemoteDesktopManagerFree.exe</Image>
+				<Image condition="excludes">Terminals.exe</Image>
+				<Image condition="excludes">chrome.exe</Image>
+				<Image condition="excludes">mRemote.exe</Image>
+				<Image condition="excludes">mRemoteNG.exe</Image>
+				<Image condition="excludes">mstsc.exe</Image>
+				<Image condition="excludes">spiceworks-finder.exe</Image>
+				<Image condition="excludes">svchost.exe</Image>
+				<Image condition="excludes">thor64.exe</Image>
+				<Image condition="excludes">thor.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1021.001,Tactic=Lateral Movement,Technique=Remote Desktop Protocol,Level=3,Alert=Suspicious RDP Connection 3391,Risk=70" groupRelation="and">
+				<Initiated>true</Initiated>
+				<DestinationPort condition="is">3391</DestinationPort>
+				<Image condition="excludes">AutomationManager.ScriptRunner64.exe</Image>
+				<Image condition="excludes">C:\Program Files (x86)\VMware\VMware Remote Console\vmrc.exe</Image>
+				<Image condition="excludes">C:\Program Files\VMware\VMware Remote Console\vmrc.exe</Image>
+				<Image condition="excludes">C:\Program Files\WindowsApps\Microsoft.RemoteDesktop_</Image>
+				<Image condition="excludes">CtxLicUsageRecorder.exe</Image>
+				<Image condition="excludes">FSAssessment.exe</Image>
+				<Image condition="excludes">FSDiscovery.exe</Image>
+				<Image condition="excludes">MobaRTE.exe</Image>
+				<Image condition="excludes">RDCMan.exe</Image>
+				<Image condition="excludes">RSSensor.exe</Image>
+				<Image condition="excludes">RTS2App.exe</Image>
+				<Image condition="excludes">RTSApp.exe</Image>
+				<Image condition="excludes">RemoteDesktopManager64.exe</Image>
+				<Image condition="excludes">RemoteDesktopManager.exe</Image>
+				<Image condition="excludes">RemoteDesktopManagerFree.exe</Image>
+				<Image condition="excludes">Terminals.exe</Image>
+				<Image condition="excludes">chrome.exe</Image>
+				<Image condition="excludes">mRemote.exe</Image>
+				<Image condition="excludes">mRemoteNG.exe</Image>
+				<Image condition="excludes">mstsc.exe</Image>
+				<Image condition="excludes">spiceworks-finder.exe</Image>
+				<Image condition="excludes">svchost.exe</Image>
+				<Image condition="excludes">thor64.exe</Image>
+				<Image condition="excludes">thor.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1021.001,Tactic=Lateral Movement,Technique=Remote Desktop Protocol,Level=3,Alert=Localhost RDP Tunneling Detection,Risk=70" groupRelation="and">
+				<Initiated>true</Initiated>
+				<DestinationPort condition="is">3389</DestinationPort>
+				<DestinationIp condition="is any">127.0.0.1;0:0:0:0:0:0:0:1</DestinationIp>
+			</Rule>
+			<Rule name="Attack=T1021.001,Tactic=Lateral Movement,Technique=Remote Desktop Protocol,Level=3,Alert=Link-Local RDP Tunnel Detection,Risk=70" groupRelation="and">
+				<Initiated>true</Initiated>
+				<DestinationPort condition="is">3389</DestinationPort>
+				<DestinationIp condition="begin with">fe80:0</DestinationIp>
+			</Rule>
+			<Rule name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=SSH Connection with Putty,Risk=80" groupRelation="and">
+				<Image condition="contains any">putty.exe;kitty.exe;kitty_portable.exe</Image><!-- SSH -->
+			</Rule>
+			<Rule name="Attack=T1028,Technique=Windows Remote Management,Tactic=Lateral Movement,Level=0,Desc=Windows Remote Management connection,Risk=0" groupRelation="and">
+				<Image condition="image">wsmprovhost.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=PSFTP Connection,Risk=70" groupRelation="and">
+				<Image condition="image">psftp.exe</Image><!-- SFTP -->
+			</Rule>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=Remote Registry via command line,Risk=30" condition="image">reg.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=Remote Registry via command line,Risk=80" condition="contains">psshutdown</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=Remote password change with PSPasswd,Risk=80" condition="contains">PsPasswd</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=Remote querying of services,Risk=80" condition="contains">psservice</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=SSH Connection with ssh.exe,Risk=30" condition="image">ssh.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=Sysinternals PSEXE Tools,Risk=100" condition="contains">psexe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=TSFTP Connection,Risk=70" condition="image">tftp.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=Telnet Connection,Risk=30" condition="image">telnet.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=0,Desc=MSTSC Remote Desktop Connection" condition="image">mstsc.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=0,Desc=Remote WMIC commands,Risk=30" condition="image">wmic.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=0,Desc=SC.exe Network Connection" condition="image">sc.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=0,Desc=Sysinternals PSKILL Tools,Risk=80" condition="contains">pskill</Image>
+			<Image name="Attack=T1087,Technique=Account Discovery,Tactic=Discovery,Level=0,Desc=DSQuery network connection" condition="image">dsquery.exe</Image>
+			<Image name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=3,Alert=Automated SSH Connection with Putty PLink,Risk=30" condition="image">plink.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=VNC" condition="image">vnc.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=VNC Viewer" condition="image">vncviewer.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=VNC Service" condition="image">vncservice.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement" condition="image">omniinet.exe</Image>
+			<Image name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement" condition="image">hpsmhd.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Replication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Deployment Tools-->
+			<!--MITRE ATT&CK TECHNIQUE: Taint Shared Content-->
+			<!--MITRE ATT&CK TECHNIQUE: Use Alternate Authentication Material-->
+
+			<!--MITRE ATT&CK TACTIC: Collection-->
+			<!--MITRE ATT&CK TECHNIQUE: Adversary-in-the-Middle-->
+			<!--MITRE ATT&CK TECHNIQUE: Archive Collected Data-->
+			<!--MITRE ATT&CK TECHNIQUE: Audio Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Automated Collection-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Session Hijacking-->
+			<!--MITRE ATT&CK TECHNIQUE: Clipboard Data-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Cloud Storage Object-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Configuration Repository-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Information Repositories-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Local System-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Network Shared Drive-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Staged-->
+			<!--MITRE ATT&CK TECHNIQUE: Email Collection-->
+			<!--MITRE ATT&CK TECHNIQUE: Input Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Screen Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Video Capture-->
+
+			<!--MITRE ATT&CK TACTIC: Command and Control-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<DestinationPort condition="is">50050</DestinationPort>
+				<Initiated>true</Initiated>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<DestinationPort condition="is">25</DestinationPort>
+				<Image condition="excludes any">\Bin\EdgeTransport.exe;Bin\MSExchangeFrontendTransport.exe</Image>
+				<Initiated>true</Initiated>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Application Layer Protocol-->
+			<!--MITRE ATT&CK TECHNIQUE: Communication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Encoding-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Obfuscation-->
+			<!--MITRE ATT&CK TECHNIQUE: Dynamic Resolution-->
+			<!--MITRE ATT&CK TECHNIQUE: Encrypted Channel-->
+			<!--MITRE ATT&CK TECHNIQUE: Fallback Channels-->
+			<!--MITRE ATT&CK TECHNIQUE: Ingress Tool Transfer-->
+			<Rule name="Attack=T1053.005,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=Powershell Network Connection,Risk=30" groupRelation="and">
+				<Image condition="image">powershell.exe</Image>
+				<DestinationIp condition="excludes any">0:0:0:0:0:0:0:;127.0.0.1</DestinationIp>
+			</Rule>
+			<Image name="Attack=T1053.005,Technique=Ingress Tool Transfer,Tactic=Command And Control,Level=3,Alert=MSHTA Network Connection,Risk=100" condition="image">mshta.exe</Image>
+			<Image name="Attack=T1053.005,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=CMD Prompt network Connection,Risk=20" condition="image">cmd.exe</Image>
+			<Image name="Attack=T1053.005,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=Certutil Connecting to network,Risk=20" condition="image">certutil.exe</Image>
+			<Image name="Attack=T1053.005,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=Bitsadmin Connecting to network,Risk=20" condition="image">certutil.exe</Image>
+			<Image name="Attack=T1053.005,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=Notepad Network Connection" condition="image">notepad.exe</Image>
+			<Image name="Attack=T1053.005,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=RegSVCS Network Connection,Risk=30" condition="image">regsvcs.exe</Image>
+			<Image name="Attack=T1053.005,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=RegSVR32 Network Connection,Risk=30" condition="image">regsvr32.exe</Image> 
+			<Image name="Attack=T1053.005,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=RunDLL32 Network Connection,Risk=30" condition="image">rundll32.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Stage Channels-->
+			<!--MITRE ATT&CK TECHNIQUE: Non-Application Layer Protocol-->
+			<!--MITRE ATT&CK TECHNIQUE: Non-Standard Port-->
+			<!--MITRE ATT&CK TECHNIQUE: Protocol Tunneling-->
+			<!--MITRE ATT&CK TECHNIQUE: Proxy-->
+			<!--MITRE ATT&CK TECHNIQUE: Proxy: Multi-hop Proxy-->
+			<Image name="Attack=T1090.003,Technique=Multi-hop Proxy,Tactic=Command And Control,Level=3,Alert=Tor Connection" condition="image">tor.exe</Image>
+			<DestinationHostname name="Attack=T1090.003,Technique=Multi-hop Proxy,Tactic=Command And Control,Level=3,Alert=Tor2Web,Risk=100" condition="contains any">hiddenservice.net;onion.city;onion.direct;onion.direct;onion.link;onion.nu;onion.pet;onion.plus;onion.rip;onion.sh;onion.sh;onion.si;onion.to;onion.top;onion.ws;tor-gateways.de;tor2net.com;tor2web.blutmagie.de;tor2web.fi;tor2web.info;tor2web.io;tor2web.org;onion.to</DestinationHostname>
+			<!--MITRE ATT&CK TECHNIQUE: Remote Access Software-->
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Web Service-->
+
+			<!--MITRE ATT&CK TACTIC: Exfiltration-->
+			<!--MITRE ATT&CK TECHNIQUE: Automated Exfiltration-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Transfer Size Limits-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Alternative Protocol-->
+			<!-- DNS Over HTTPS-->
+			<DestinationHostname name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=0,Desc=DNS Over HTTPS" condition="contains any">dns.google;cloudflare-dns.com;mozilla.cloudflare-dns.com;dns.233py.com;dns.aaflalo.me;doh.opendns.com;.quad9.net;dns.cleanbrowsing.org;dns-family.adguard.com;dns.adguard.com;.233py.com;dnscrypt;dnscrypt-cert.oszx.co;dns.oszx.co;doh.dns.sb;doh.defaultroutes.de;doh.tiarap.org;doh.tiar.app;doh.captnemo.in;.aaflalo.me;doh.appliedprivacy.net;doh.dnswarden.com;commons.host;dns.twnic.tw;ibuki.cgnat.net;doh.xfinity.com;dns.nextdns.io;dns.dnsoverhttps.net;doh.crypto.sx;doh.powerdns.org;.blahdns.com;dns.rubyfish.cn;dns.containerpi.com;.seby.io;rdns.faelix.net;doh.li;.armadillodns.net;doh.netweaver.uk;doh.42l.fr;dns.aa.net.uk;adblock.mydns.network;ibksturm.synology.me;jcdns.fun</DestinationHostname>
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over C2 Channel-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Other Network Medium-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Physical Medium-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Web Service-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Transfer-->
+			<!--MITRE ATT&CK TECHNIQUE: Transfer Data to Cloud Account-->
+			<DestinationHostname name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=0,Desc=privatlab.com Cloud Exfiltration" condition="contains all">privatlab.com</DestinationHostname>
+			<DestinationHostname name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=3,Alert=Mega.co.nz Cloud Exfiltration" condition="contains any">mega.nz;mega.co.nz</DestinationHostname>
+			<DestinationHostname name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=3,Alert=PCloud Cloud storage Exfiltration" condition="contains any">.pcloud.com</DestinationHostname>
+			<!--MITRE ATT&CK TACTIC: Impact-->
+			<!--MITRE ATT&CK TECHNIQUE: Account Access Removal-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Destruction-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Encrypted for Impact-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: Defacement-->
+			<!--MITRE ATT&CK TECHNIQUE: Disk Wipe-->
+			<!--MITRE ATT&CK TECHNIQUE: Endpoint Denial of Service-->
+			<!--MITRE ATT&CK TECHNIQUE: Firmware Corruption-->
+			<!--MITRE ATT&CK TECHNIQUE: Inhibit System Recovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Denial of Service-->
+			<!--MITRE ATT&CK TECHNIQUE: Resource Hijacking-->
+			<DestinationHostname name="Level=4,Alert=Crypto Currency Miner Detected,Attack=T1496,Technique=Resource Hijacking,Tactic=Impact,Risk=100" condition="contains any">0x1f4b0.com;1q2w3.life;1q2w3.website;31.187.64.216;185.193.38.148;aalbbh84.info;adfreetv.ch;adless.io;adplusplus.fr;adrenali.gq;ajcryptominer.com;ajplugins.com;allfontshere.press;altavista.ovh;amhixwqagiz.ru;analytics.blue;appelamule.com;arizona-miner.tk;aster18cdn.nl;aster18prx.nl;avero.xyz;averoconnector.com;bauersagtnein.myeffect.net;bhzejltg.info;blazepool;blockmasters;blockmasterscoins;bmnr.pw;bmst.pw;bohemianpool;carry.myeffect.net;cashbeet.com;cdn-code.host;cfceu.duckdns.org;cfcnet.gdn;cfcnet.top;cfcs1.duckdns.org;chainblock.science;cieh.mx;coin-hive.com;coin-service.com;coin-services.info;coiner.site;coinpirate.cf;coinrail.io;coinwebmining.com;cpu2cash.link;cryptaloot.pro;cryptmonero;crypto-loot.com;crypto-pool;crypto-webminer.com;cryptoloot.pro;d-ns.ga;dataservices.download;directprimal.com;dwarfpool;encoding.ovh;estream.to;eth-pocket.com;eth-pocket.de;eth-pocket.eu;ethereum-pocket.de;ethereum-pocket.eu;ethtrader.de;eu.sushipool.com;f1tbit.com;flnqmin.org;freecontent.bid;freecontent.date;freecontent.loan;freecontent.racing;freecontent.stream;freecontent.win;gnrdomimplementation.com;graftpool.ovh;greenindex.dynamic-dns.net;gustaver.ddns.net;hashrefinery;hashvault.pro;herphemiste.com;hide.ovh;hk.rs;hlpidkr.ru;hodlers.party;hodling.faith;hostingcloud.win;hrfziiddxa.ru;ihdvilappuxpgiv.ru;imhvlhaelvvbrq.ru;insdrbot.com;irrrymucwxjl.ru;istlandoll.com;ivuovhsn.ru;iwanttoearn.money;ixvenhgwukn.ru;jqassets.download;jqr-cdn.download;jqrcdn.download;jquerrycdn.download;jqwww.download;jqxrrygqnagn.ru;jscoinminer.com;jwduahujge.ru;ksimdw.ru;l33tsite.info;laferia.cr;ledhenone.com;ltstyov.ru;mepirtedic.com;mine.bz;minercircle.com;minercry.pt;minergate;minero.cc;miners.pro;minescripts.info;mininghub.club;miningpoolhubcoins;minr.pw;mixpools.org;mmc.center;mollnia.com;monerise.com;monero.lindon-pool.win;monero;moriaxmr.com;munero.me;mxcdn1.now.sh;mxcdn2.now.sh;myadstats.com;mypool.online;nablabee.com;nanopool.org;nathetsof.com;nicehash;nimiqpool.com;nimpool.io;node.philpool.com;npcdn1.now.sh;nunu-001.now.sh;ogondkskyahxa.ru;ogrid.org;oinkinns.tk;olecintri.com;omine.org;onvid.club;open-hive-server-1.pp.ua;oxwwoeukjispema.ru;pcejuyhjucmkiny.ru;pool.nimiq.watch;pool.nimiqchain.info;pool.porkypool.com;pool.xmr;poolto.be;prohash.net;prohash;proj2018.xyz;pzoifaum.info;ratchetmining.com;realnetwrk.com;reauthenticator.com;rove.cl;ruvuryua.ru;s7ven.com;scaleway.ovh;sentemanactri.com;sickrage.ca/ch;sighash.info;slushpool;soodatmish.com;sparechange.io;statdynamic.com;stati.bid;staticsfs.host;streamplay.to;supportxmr;suprnova.cc;svivqrhrh.ru;sxcdn02.now.sh;sxcdn3.now.sh;sxcdn4.now.sh;sxcdn6.now.sh;synconnector.com;teracycle.net;tercabilis.info;thelifeisbinary.ddns.net;thersprens.com;torrent.pw;ulnawoyyzbljc.ru;unrummaged.com;uoldid.ru;usxmrpool;viaxmr.com;vpzccwpyilvoyg.ru;vzzexalcirfgrf.ru;wbmwss.beetv.net;webmine.cz;webmine.pro;webminepool.tk;webminerpool.com;webwidgetz.duckdns.org;wmemsnhgldd.ru;wmtech.website;wmwmwwfmkvucbln.ru;wrxgandsfcz.ru;xmrm.pw;xmrminingproxy.com;xmrpool;yiimp;yuyyio.com;zavzlen.ru;zergpool;zergpoolcoins;ziykrgc.ru;zlx.com.br;zpool</DestinationHostname>
+			<!--MITRE ATT&CK TECHNIQUE: Service Stop-->
+			<!--MITRE ATT&CK TECHNIQUE: System Shutdown/Reboot-->
+			<!--UEBA Rules-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">C:\Windows\system32\svchost.exe</Image>
+				<DestinationPort condition="is not">3389</DestinationPort>
+				<DestinationPort condition="is not">22</DestinationPort>
+				<DestinationPort condition="is not">21</DestinationPort>
+				<DestinationPort condition="is not">5985</DestinationPort>
+				<Initiated>false</Initiated>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">C:\Windows\system32\svchost.exe</Image>
+				<Initiated>true</Initiated>
+				<SourcePort condition="is not">135</SourcePort>
+				<SourcePort condition="is not">445</SourcePort>
+				<DestinationPort condition="is not">5985</DestinationPort>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="is not">System</Image>
+				<Image condition="excludes">svchost.exe</Image>
+				<DestinationPort condition="is">445</DestinationPort>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="is not">System</Image>
+				<Image condition="excludes any">svchost.exe;lsass.exe</Image>
+				<DestinationPort condition="is">389</DestinationPort>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">C:\Windows\System32\lsass.exe</Image>
+				<DestinationPort condition="is">389</DestinationPort>
+				<DestinationIp condition="excludes any">127.0.0.1;0:0:0:0:0:0:0:1;fe80:0</DestinationIp>
+				<SourceHostname condition="excludes any">EXCH</SourceHostname>
+				<SourceIp condition="excludes any">127.0.0.1;0:0:0:0:0:0:0:1;fe80:0</SourceIp>
+				<Initiated>false</Initiated>
+			</Rule>
+			<Rule name="Level=4,Alert=Notepad connecting to the internet" groupRelation="and">
+				<Image condition="image">notepad.exe</Image>
+				<DestinationIp condition="excludes">127.0.0.1</DestinationIp>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">\iexplore.exe;\chrome.exe;\firefox.exe;\MicrosoftEdge;browser_broker.exe;\vivaldi.exe;\brave.exe</Image>
+				<DestinationPort condition="is not">80</DestinationPort>
+				<DestinationPort condition="is not">443</DestinationPort>
+				<Initiated>true</Initiated>
+			</Rule>
+			<DestinationHostname name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">github</DestinationHostname> 
+			<DestinationHostname name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">githubusercontent.com</DestinationHostname>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">\iexplore.exe;\chrome.exe;\firefox.exe;\MicrosoftEdge;browser_broker.exe;\vivaldi.exe;\brave.exe</Image>
+				<DestinationPort condition="is">80</DestinationPort>
+				<Initiated>true</Initiated>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">\iexplore.exe;\chrome.exe;\firefox.exe;\MicrosoftEdge;browser_broker.exe;\vivaldi.exe;\brave.exe</Image>
+				<DestinationPort condition="is">443</DestinationPort>
+				<Initiated>true</Initiated>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">apache.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">java.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">w3wp.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">\php-cgi.exe;\php.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains">setup</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains">tomcat</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains">unins</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains">unknown process</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains">explorer.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">inetinfo.exe</Image>
+			</Rule>
+			<!--3rd Party tools-->
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains any">netcat.exe;nc.exe;nc64.exe;ncat.exe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains any">procdump</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains any">psexe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains any">vnc;vncs;vncv</Image>
+			<Rule name="Attack=T1595.002,Technique=Vulnerability Scanning,Tactic=Reconnaissance,Level=4,Alert=Port Scan Tool Detected,Risk=100" groupRelation="or">
+				<Image condition="contains any">rcpping;tcpping;tcping;routerscan;grabff;Port-Scan;netscan;\nmap;ipscan;nacmdline.exe;advanced_port_scanner.exe;rcpping.exe;nmap.exe;zenmap.exe;advanced_ip_scanner.exe</Image>
+			</Rule>
+			<!--Destination Ports to Monitor-->
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">0</DestinationPort>
+			<DestinationPort name="Attack=T1028,Technique=Windows Remote Management,Tactic=Lateral Movement,Level=0,Desc=Powershell Remoting,Risk=0" condition="is">5985</DestinationPort>
+			<DestinationPort name="Attack=T1028,Technique=Windows Remote Management,Tactic=Lateral Movement,Level=0,Desc=Powershell Remoting,Risk=0" condition="is">5986</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">1293</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">1701</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">1194</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">3540</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">3389</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">22</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">1080</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">3128</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">8080</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">1723</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">23</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">4500</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">9001</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">9030</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">5900</DestinationPort>
+			<DestinationPort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">5800</DestinationPort>
+			<!--Source Ports to Monitor-->
+			<SourcePort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">0</SourcePort>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="excludes any">\iexplore.exe;\chrome.exe;\firefox.exe;\MicrosoftEdge;browser_broker.exe;\vivaldi.exe;\brave.exe</Image>
+				<DestinationPort condition="is">443</DestinationPort>
+				<Initiated>true</Initiated>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="excludes any">\iexplore.exe;\chrome.exe;\firefox.exe;\MicrosoftEdge;browser_broker.exe;\vivaldi.exe;\brave.exe</Image>
+				<DestinationPort condition="is">80</DestinationPort>
+				<Initiated>true</Initiated>
+			</Rule>
+			<SourcePort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">80</SourcePort>
+			<SourcePort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">443</SourcePort>
+			<SourcePort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">636</SourcePort>
+			<SourcePort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">5900</SourcePort>
+			<SourcePort name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">443</SourcePort>
+			<!--Suspicious network connections-->
+			<DestinationHostname name="Attack=T1311,Technique=Dynamic DNS,Tactic=Adversary Opsec,Level=4,Alert=Dynamic DNS Connection" condition="contains any">afraid.org;duckdns.org;changeip.com;ddns.net;hopto.org;zapto.org;servehttp.com;sytes.net;whoer.net;bravica.net;ip.webmasterhome.cn;whatsmyip.us;myip.kz;ip-addr.es;curlmyip;anysrc.net;anysrc.net;dlinkddns.com;no-ip.com;no-ip.org;no-ip.biz;no-ip.info;noip.com</DestinationHostname>
+		</NetworkConnect>
+	</RuleGroup>
+	<RuleGroup name="RG=NetworkConnect Exclude Group" groupRelation="or">
+		<NetworkConnect onmatch="exclude">
+			<Protocol condition="contains">udp</Protocol>
+			<!--Exclude Inter-process coms over localhost, may be dangerous at expense for noise reduction -->
+			<Rule name="exclude interprocess communications with localhost" groupRelation="and">
+				<Image condition="contains any">System;svchost.exe;oracle.exe;apache.exe;java.exe;php-cgi.exe;w3wp.exe;httpd;ServerManager.exe;unknown process;sql;wscript;cscript;schtasks;at.exe;reg.exe;C:\Windows\System32\find.exe</Image>
+				<SourceIp condition="is any">127.0.0.1;0:0:0:0:0:0:0:1</SourceIp>
+				<DestinationIp condition="is any">127.0.0.1;0:0:0:0:0:0:0:1</DestinationIp>
+			</Rule>
+			<!--SECTION: Custom -->
+			<Rule name="exclude dest ldap port 88" groupRelation="and">
+				<Image condition="image">C:\Windows\System32\lsass.exe</Image>
+				<DestinationPort condition="is">88</DestinationPort>
+			</Rule>
+			<!--Disable Monitoring of Protocols-->
+			<DestinationPortName condition="is">epmap</DestinationPortName>
+			<DestinationPortName condition="is">llmnr</DestinationPortName>
+			<DestinationPortName condition="is">microsoft-ds</DestinationPortName>
+			<DestinationPortName condition="is">netbios-dgm</DestinationPortName>
+			<DestinationPortName condition="is">ntp</DestinationPortName>
+			<DestinationPortName condition="is">ssdp</DestinationPortName>
+			<SourcePortName condition="is">epmap</SourcePortName>
+			<SourcePortName condition="is">llmnr</SourcePortName>
+			<SourcePortName condition="is">microsoft-ds</SourcePortName>
+			<SourcePortName condition="is">netbios-dgm</SourcePortName>
+			<SourcePortName condition="is">ntp</SourcePortName>
+			<SourcePortName condition="is">ssdp</SourcePortName>
+			<!--Disable Monitoring on Ports-->
+			<DestinationPort condition="is">53</DestinationPort>   <!--DNS Lookups-->
+			<DestinationPort condition="is">67</DestinationPort>  <!--Bootp Lookups-->
+			<DestinationPort condition="is">68</DestinationPort>  <!--Bootp Lookups-->
+			<DestinationPort condition="is">1434</DestinationPort>  <!--SQL spam.-->
+			<DestinationPort condition="is">1812</DestinationPort> <!--Radius-->
+			<DestinationPort condition="is">3544</DestinationPort> <!--Teredo-->
+			<DestinationPort condition="is">3702</DestinationPort> <!--Windows: WS-Discovery noise-->
+			<DestinationPort condition="is">5228</DestinationPort> <!--Google Chrome Safe Search checks-->
+			<DestinationPort condition="is">5353</DestinationPort> <!--Bonjour/Avahi Discovery-->
+			<DestinationPort condition="is">5357</DestinationPort> <!--WSD API noise-->
+			<DestinationPort condition="is">5989</DestinationPort>  <!--Vcenter Secure server for CIM.-->
+			<DestinationPort condition="is">6007</DestinationPort>  <!--Exchange WMI Spam-->
+			<DestinationPort condition="is">49154</DestinationPort>  <!--DFRS/ADFS Replication spam-->
+			<DestinationPort condition="is">49209</DestinationPort>  <!--DFRS/ADFS Replication spam-->
+			<DestinationPort condition="is">52176</DestinationPort>  <!--DFRS/ADFS Replication spam-->
+			<DestinationPort condition="is">59241</DestinationPort>  <!--DFRS/ADFS Replication spam-->
+			<SourcePort condition="is">53</SourcePort>  <!--DNS Lookups-->
+			<SourcePort condition="is">67</SourcePort>  <!--Bootp Lookups-->
+			<SourcePort condition="is">68</SourcePort>  <!--Bootp Lookups-->
+			<SourcePort condition="is">1812</SourcePort> <!--Radius-->
+			<SourcePort condition="is">3702</SourcePort> <!--Windows: WS-Discovery noise-->
+			<SourcePort condition="is">6007</SourcePort>  <!--Exchange WMI Spam-->
+			<SourcePort condition="is">49154</SourcePort>  <!--DFRS/ADFS Replication spam-->
+			<SourcePort condition="is">49209</SourcePort>  <!--DFRS/ADFS Replication spam-->
+			<SourcePort condition="is">50646</SourcePort> <!--Windows: WS-Discovery noise-->
+			<SourcePort condition="is">52176</SourcePort>  <!--DFRS/ADFS Replication spam-->
+			<SourcePort condition="is">59241</SourcePort>  <!--DFRS/ADFS Replication spam-->
+			<!--SECTION: Microsoft -->
+			<DestinationHostname condition="end with">.bing.com</DestinationHostname>
+			<DestinationHostname condition="end with">.cloudapp.net</DestinationHostname>
+			<DestinationHostname condition="end with">.lync.com</DestinationHostname>
+			<DestinationHostname condition="end with">.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">.outlook.com</DestinationHostname>
+			<DestinationHostname condition="end with">.search.msn.com</DestinationHostname>
+			<DestinationHostname condition="end with">.wns.windows.com</DestinationHostname>
+			<DestinationHostname condition="end with">aps.windows.com</DestinationHostname>
+			<DestinationHostname condition="end with">arc.msn.com.nsatc.net</DestinationHostname>
+			<DestinationHostname condition="end with">arc.msn.com</DestinationHostname>
+			<DestinationHostname condition="end with">atson.telemetry.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">au.download.windowsupdate.com</DestinationHostname>
+			<DestinationHostname condition="end with">b.akamaiedge.net</DestinationHostname>
+			<DestinationHostname condition="end with">bingforbusiness.com</DestinationHostname>
+			<DestinationHostname condition="end with">client-office365-tas.msedge.net</DestinationHostname>
+			<DestinationHostname condition="end with">config.edge.skype.com</DestinationHostname>
+			<DestinationHostname condition="end with">csp.digicert.com</DestinationHostname>
+			<DestinationHostname condition="end with">ctldl.windowsupdate.com</DestinationHostname>
+			<DestinationHostname condition="end with">cy2.licensing.md.mp.microsoft.com.akadns.net</DestinationHostname>
+			<DestinationHostname condition="end with">cy2.settings.data.microsoft.com.akadns.net</DestinationHostname>
+			<DestinationHostname condition="end with">displaycatalog.mp.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">download.windowsupdate.com</DestinationHostname>
+			<DestinationHostname condition="end with">e-msedge.net</DestinationHostname>
+			<DestinationHostname condition="end with">e3.delivery.dsp.mp.microsoft.com.nsatc.net</DestinationHostname>
+			<DestinationHostname condition="end with">emdl.ws.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">ettings-win.data.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">fe2.update.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">fe3.delivery.dsp.mp.microsoft.com.nsatc.net</DestinationHostname>
+			<DestinationHostname condition="end with">fe3.delivery.mp.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">g.akamaiedge.net</DestinationHostname>
+			<DestinationHostname condition="end with">g.live.com</DestinationHostname>
+			<DestinationHostname condition="end with">g.msn.com.nsatc.net</DestinationHostname>
+			<DestinationHostname condition="end with">geo-prod.do.dsp.mp.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">geo-prod.dodsp.mp.microsoft.com.nsatc.net</DestinationHostname>
+			<DestinationHostname condition="end with">ile-service.weather.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">ip5.afdorigin-prod-am02.afdogw.com</DestinationHostname>
+			<DestinationHostname condition="end with">ipv4.login.msa.akadns6.net</DestinationHostname>
+			<DestinationHostname condition="end with">licensing.mp.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">m3p.wns.notify.windows.com.akadns.net</DestinationHostname>
+			<DestinationHostname condition="end with">microsoft.com.akadns.net</DestinationHostname>
+			<DestinationHostname condition="end with">microsoft.com.nsatc.net</DestinationHostname>
+			<DestinationHostname condition="end with">microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">modern.watson.data.microsoft.com.akadns.net</DestinationHostname>
+			<DestinationHostname condition="end with">msedge.net</DestinationHostname>
+			<DestinationHostname condition="end with">msn.com.nsatc.net</DestinationHostname>
+			<DestinationHostname condition="end with">msn.com</DestinationHostname>
+			<DestinationHostname condition="end with">ocation-inference-westus.cloudapp.net</DestinationHostname>
+			<DestinationHostname condition="end with">ocos-office365-s2s.msedge.net</DestinationHostname>
+			<DestinationHostname condition="end with">ocsp.digicert.com</DestinationHostname>
+			<DestinationHostname condition="end with">odern.watson.data.microsoft.com.akadns.net</DestinationHostname>
+			<DestinationHostname condition="end with">oneclient.sfx.ms</DestinationHostname>
+			<DestinationHostname condition="end with">pv4.login.msa.akadns6.net</DestinationHostname>
+			<DestinationHostname condition="end with">query.prod.cms.rt.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">ris.api.iris.microsoft.com.akadns.net</DestinationHostname>
+			<DestinationHostname condition="end with">ris.api.iris.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">s-msedge.net</DestinationHostname>
+			<DestinationHostname condition="end with">settings.data.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">sfe.trafficshaping.dsp.mp.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">sls.update.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">storecatalogrevocation.storequality.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">storeedgefd.dsx.mp.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">telecommand.telemetry.microsoft.com.akadns.net</DestinationHostname>
+			<DestinationHostname condition="end with">tile-service.weather.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">tlu.dl.delivery.mp.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">tsfe.trafficshaping.dsp.mp.microsoft.com</DestinationHostname>
+			<DestinationHostname condition="end with">vip5.afdorigin-prod-am02.afdogw.com</DestinationHostname>
+			<DestinationHostname condition="end with">vip5.afdorigin-prod-ch02.afdogw.com</DestinationHostname>
+			<DestinationHostname condition="end with">virtualearth.net</DestinationHostname>
+			<DestinationHostname condition="end with">windows.net</DestinationHostname>
+			<DestinationHostname condition="end with">windowsupdate.com</DestinationHostname>
+			<DestinationHostname condition="end with">y2.displaycatalog.md.mp.microsoft.com.akadns.net</DestinationHostname>
+			<DestinationHostname condition="end with">y2.licensing.md.mp.microsoft.com.akadns.net</DestinationHostname>
+			<DestinationHostname condition="end with">y2.settings.data.microsoft.com.akadns.net</DestinationHostname>
+			<Image condition="image">EdgeTransport.exe</Image>
+			<Image condition="image">MSExchangeDelivery.exe</Image>
+			<Image condition="image">MSExchangeFrontendTransport.exe</Image>
+			<Image condition="image">MSExchangeHMWorker.exe</Image>
+			<Image condition="image">MSExchangeSubmission.exe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">\</Image>
+		</NetworkConnect>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 4 : RESERVED FOR SYSMON STATUS MESSAGES-->
+
+		<!--DATA: UtcTime, State, Version, SchemaVersion-->
+		<!--Cannot be filtered.-->
+
+	<!--SYSMON EVENT ID 5 : PROCESS ENDED [ProcessTerminate]-->
+		<!--COMMENT:	Useful data in building infection timelines.-->
+		<RuleGroup name="RG=ProcessTerminate Include Group" groupRelation="or">
+		<ProcessTerminate onmatch="include">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="begin with">C:\Windows\</Image>
+				<Image condition="excludes">\System32\;Syswow64;sysmon.exe;sysmon64.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="begin with">C:\Windows\system32\</Image>
+				<Image condition="excludes">config\systemprofile\</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">C:\Windows\sysmon.exe;C:\Windows\sysmon64.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">A:\;B:\;C:\;D:\;E:\;F:\;G:\;H:\;I:\;J:\;K:\;L:\;M:\;N:\;O:\;P:\;Q:\;R:\;S:\;T:\;U:\;V:\;W:\;X:\;Y:\;Z:\;AA:\;BB:\;CC:\;DD:\;EE:\;FF:\;GG:\;HH:\;II:\;JJ:\;KK:\;LL:\;MM:\;NN:\;OO:\;PP:\;QQ:\;RR:\;SS:\;TT:\;UU:\;VV:\;WW:\;XX:\;YY;ZZ:\</Image>
+				<Image condition="excludes">:\PROGRA~</Image>
+				<Image condition="excludes">:\Program Files</Image>
+				<Image condition="excludes">:\Program Files</Image>
+				<Image condition="excludes">:\Program Files</Image>
+				<Image condition="excludes">:\ProgramData\</Image>
+				<Image condition="excludes">:\Users\</Image>
+				<Image condition="excludes">:\Windows\</Image>
+				<Image condition="excludes">:\inetpub\</Image>
+				<Image condition="excludes">:\$SysReset</Image>
+				<Image condition="excludes">:\$WinREAgent</Image>
+				<Image condition="excludes">:\inetpub\</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="begin with">\</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="begin with">C:\Users\</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="begin with">C:\ProgramData\</Image>
+				<Image condition="excludes any">C:\ProgramData\sysmon\sysmon64.exe;C:\ProgramData\sysmon\sysmon.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">C:\Program Files;C:\PROGRA~</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="begin with">C:\inetpub\</Image>
+			</Rule>
+		<!-- Useful data in building infection timelines.-->
+			<Image name="Attack=T1036,Tactic=Masquerading,Technique=Defense Evasion,Level=4,Alert=Process Termination in Recyclebin,Risk=100" condition="contains">$RECYCLE.BIN</Image>
+			<Image name="Attack=T1562,Technique=Impair Defenses,Tactic=Defense Evasion,Level=0,Desc=Process Terminate: Killing of Log Shippers" condition="contains any">packetbeat.exe;metricbeat.exe;filebeat.exe;winlogbeat.exe;o365beat.exe;graylog-sidecar.exe;graylog-collector-sidecar.exe;splunkd.exe;splunk.exe;syslogng.exe;syslog-ng.exe;nxlog-processor.exe;snarecore.exe;fluentd;td-agent</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\system32\config\systemprofile\</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\sysWOW64\config\systemprofile\</Image>
+			<Image condition="contains">\Temp\</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">C:\Users\</Image>
+		</ProcessTerminate>
+	</RuleGroup>
+	<RuleGroup name="RG=ProcessTerminate Exclude Group" groupRelation="or">
+			<ProcessTerminate onmatch="exclude">
+			<Image condition="end with">Microsoft\Teams\current\Teams.exe</Image>
+			<Image condition="end with">\git.exe</Image>
+			<Image condition="end with">Microsoft\EdgeUpdate\MicrosoftEdgeUpdate.exe</Image>
+			<Image condition="begin with">C:\ProgramData\Lenovo\ImController\</Image>
+		</ProcessTerminate>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 6 : DRIVER LOADED INTO KERNEL [DriverLoad]-->
+	<RuleGroup name="RG=DriverLoad Include Group" groupRelation="or">
+		<DriverLoad onmatch="include">
+			<Rule name="Attack=T1195,Technique=Supply Chain Compromise,Tactic=Initial Access,Level=4,Alert=Solarwinds/FireEye sunburst driver hashes,Risk=100" groupRelation="and">
+				<Hashes condition="contains any">56ceb6d0011d87b6e4d7023d7ef85676;4f2eb62fa529c0283b28d05ddd311fae;b91ce2fa41029f6955bff20079468448;b91ce2fa41029f6955bff20079468448;846e27a652a5e1bfbd0ddd38a16dc865;2c4a910a1299cdae2a4e55988a2f102e</Hashes><!-- exclude non executable files -->
+			</Rule>
+			<Rule name="Attack=T1195,Technique=Supply Chain Compromise,Tactic=Initial Access,Level=4,Alert=Vulnerable Dell Drivers Detected,Risk=100" groupRelation="and">
+				<Hashes condition="contains any">0296e2ce999e67c76352613a718e11516fe1b0efc3ffdb8918fc999dd76a73a5;c948ae14761095e4d76b55d9de86412258be7afd;c996d7971c49252c582171d9380360f2;ddbf5ecca5c8086afde1fb4f551e9e6400e94f4428fe7fb5559da5cffa654cc1;10b30bdee43b3a2ec4aa63375577ade650269d25;d2fd132ab7bbc6bbb87a84f026fa0244</Hashes><!-- exclude non executable files -->
+			</Rule>
+			<ImageLoaded name="Attack=T1003,Tactic=Credential Access,Technique=OS Credential Dumping,Level=4,Alert=DumpExt.dll driver loaded,Risk=100" condition="contains">DumpExt.dll</ImageLoaded>
+			<ImageLoaded name="Attack=T1003,Tactic=Credential Access,Technique=OS Credential Dumping,Level=4,Alert=Mimikatz driver loaded,Risk=100" condition="contains">mimidrv</ImageLoaded>
+			<ImageLoaded name="Attack=T1003,Tactic=Credential Access,Technique=OS Credential Dumping,Level=4,Alert=PWDump6 driver loaded,Risk=100" condition="contains">lsremora</ImageLoaded>
+			<ImageLoaded name="Attack=T1003,Tactic=Credential Access,Technique=OS Credential Dumping,Level=4,Alert=wceaux.dll driver loaded,Risk=100" condition="contains">wceaux.dll</ImageLoaded>
+			<ImageLoaded name="Attack=T1040,Tactic=Discovery,Technique=Network Sniffing,Level=4,Alert=NPCap packet capture driver loaded,Risk=100" condition="contains">npcap</ImageLoaded>
+			<ImageLoaded name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Temp</ImageLoaded>
+			<ImageLoaded name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">:\Users</ImageLoaded>
+			<Signature name="Attack=T1019,Technique=System Firmware,Tactic=Persistence,Level=4,Alert=UEFI Rootkit detection,Risk=100" condition="contains">ChongKim Chan</Signature>
+			<SignatureStatus condition="contains">?</SignatureStatus>
+			<SignatureStatus condition="contains">Revoked</SignatureStatus>
+			<SignatureStatus condition="contains">Unavailable</SignatureStatus>
+			<SignatureStatus condition="contains">Valid</SignatureStatus>
+			<Signed name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">false</Signed>
+		</DriverLoad>
+	</RuleGroup>
+	<RuleGroup name="RG=DriverLoad Exclude Group" groupRelation="or">
+		<DriverLoad onmatch="exclude">
+		<!--COMMENT:	Because drivers with bugs can be used to escalate to kernel permissions, be extremely selective
+				about what you exclude from monitoring. Low event volume, little incentive to exclude.-->
+		</DriverLoad>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 7 : DLL (IMAGE) LOADED BY PROCESS [ImageLoad]-->
+		<!--COMMENT:	Can cause high system load, disabled by default.-->
+		<!--DATA: RuleName, UtcTime, ProcessGuid, ProcessId, Image, ImageLoaded, Hashes, Signed, Signature, SignatureStatus-->
+	<RuleGroup name="RG=Image Load Includes" groupRelation="or">
+		<ImageLoad onmatch="include">
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=MSDT Loading diagnostic library: Dogwalk/follina,Risk=100,CVE=CVE-2022-30190" groupRelation="and">
+				<Image condition="is">msdt.exe</Image>
+				<ImageLoaded condition="contains">sdiageng.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">WINWORD.exe;EXCEL.EXE</Image>
+				<ImageLoaded condition="contains all">VBE7.DLL;VBE7INTL.DLL;VBEUI.DLL;wshom.ocx</ImageLoaded>
+				<ImageLoaded condition="excludes all">wbemdisp.dll;wbemcomn.dll;wbemprox.dll;wmiutils.dll;wbemsvc.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ImageLoaded condition="image">ntkrnlmp.exe</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,CVE=CVE-2021-1675,Level=0,Desc=Printer Expoit,Risk=100" groupRelation="and">
+				<ImageLoaded condition="contains any">\spool\drivers\x64\3\;\spool\drivers\W32X86\3\;\spool\drivers\IA64\3\</ImageLoaded>
+				<Image condition="contains any">spoolsv.exe;printisolationhost.exe</Image>
+				<SignatureStatus condition="excludes">Valid</SignatureStatus>
+				<Company condition="excludes any">Brother Industries;Canon;Sharp;Microsoft Corporation;DYMO;Euro Plus d.o.o;HP Inc;Hewlett-Packard</Company>
+			</Rule>
+			<Rule name="Attack=T1218,Technique=System Binary Proxy Execution,Tactic=Defense Evasion,Level=0,Desc=DLL Image Load by System in Suspicious Locations" groupRelation="and">
+				<Image condition="begin with">C:\Windows\</Image>
+				<ImageLoaded condition="contains any">\Users\Public\;\Desktop\;\Downloads\;\AppData\Local\Temp\;\PerfLogs\;$Recycle;\Fonts\</ImageLoaded>
+				<ImageLoaded condition="excludes any">\Program Files</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">EQNEDT32.EXE</Image>
+				<ImageLoaded condition="contains">EQNEDT32.EXE</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=T1033,Technique=System Owner/User Discovery,Tactic=Discovery,Level=2,Alert=Windows Active Directory Services DLL Loading in Susicious Directories,Risk=100" groupRelation="and">
+				<ImageLoaded condition="contains any">ACTIVEDS.DLL;Adsldpc.dll;Wldap32.dll;adsldp.dll</ImageLoaded>
+				<Image condition="contains any">C:\Users;\Temp\;\ProgramData\</Image>
+			</Rule>
+			<Rule name="Attack=T1033,Technique=System Owner/User Discovery,Tactic=Discovery,Level=2,Alert=Windows Active Directory Services DLL Loading by Suspicious Process,Risk=100" groupRelation="and">
+				<ImageLoaded condition="contains any">ACTIVEDS.DLL;Adsldpc.dll;Wldap32.dll;adsldp.dll</ImageLoaded>
+				<Image condition="contains any">wscript.exe;cscript.exe;powershell.exe;rundll32.exe;msbuild.exe;msiexec.exe;csc.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">WINWORD.exe;EXCEL.EXE</Image>
+				<ImageLoaded condition="contains all">VBEUI.DLL;VBE6.DLL;VBE6INTL.DLL;wshom.ocx</ImageLoaded>
+				<ImageLoaded condition="excludes all">wbemdisp.dll;wbemcomn.dll;wbemprox.dll;wmiutils.dll;wbemsvc.dll;fastprox.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">WINWORD.exe;EXCEL.EXE</Image>
+				<ImageLoaded condition="contains all">VBE7.DLL;VBE7INTL.DLL;VBEUI.DLL;wbemdisp.dll;wbemcomn.dll;wbemprox.dll;wmiutils.dll;wbemsvc.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">WINWORD.exe;EXCEL.EXE</Image>
+				<ImageLoaded condition="contains all">VBEUI.DLL;VBE6.DLL;VBE6INTL.DLL;wbemdisp.dll;wbemcomn.dll;wbemprox.dll;wmiutils.dll;wbemsvc.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">WINWORD.exe;EXCEL.EXE</Image>
+				<ImageLoaded condition="is">taskschd.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">wscript.exe;cscript.exe</Image>
+				<ImageLoaded condition="is">taskschd.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">wmiprvse.exe</Image>
+				<ImageLoaded condition="is">taskschd.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">powershell.exe</Image>
+				<ImageLoaded condition="is">msi.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains">powershell</Image>
+				<ImageLoaded condition="is">amsi.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="excludes">powershell</Image>
+				<ImageLoaded condition="is">amsi.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">WINWORD.exe;EXCEL.EXE</Image>
+				<ImageLoaded condition="is">clr.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ImageLoaded condition="contains all">clr.dll;System.Management.ni.dll;Microsoft.Build.Utilities</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">wscript.exe;cscript.exe</Image>
+				<ImageLoaded condition="contains all">msxml;wshom.ocx</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">wscript.exe;cscript.exe</Image>
+				<ImageLoaded condition="contains all">winhttp.dll;mswsock.dll;IPHLPAPI.DLL</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">installutil.exe</Image>
+				<ImageLoaded condition="contains all">CustomMarshalers.dll;CustomMarshalers.ni.dll;System.Management.ni.dll;WMINet_Utils.dll;mswsock.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ImageLoaded condition="end with">System.Management.Automation.ni.dll</ImageLoaded>
+				<ImageLoaded condition="begin with">C:\Windows\Microsoft.NET\assembly\GAC_MSIL\</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ImageLoaded condition="end with">System.Management.Automation.dll</ImageLoaded>
+				<ImageLoaded condition="begin with">C:\Windows\Microsoft.NET\assembly\GAC_MSIL\</ImageLoaded>
+				<ImageLoaded condition="excludes any">Lenovo.Vantage.AddinHost;\Microsoft.Sara.exe;C:\Program Files\CONEXANT</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ImageLoaded condition="is">C:\Windows\System32\vaultcli.dll</ImageLoaded>
+				<Image condition="excludes any">\svchost.exe;\GameBar.exe;C:\Program Files\WindowsApps;\Microsoft\Teams\current\Teams.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ImageLoaded condition="begin with">\\</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ImageLoaded condition="contains">\Microsoft\Word\Startup\</ImageLoaded>
+				<ImageLoaded condition="end with">.wll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ImageLoaded condition="contains">\Microsoft\Excel\Startup\</ImageLoaded>
+				<ImageLoaded condition="end with">.xll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ImageLoaded condition="contains">\Microsoft\Addins\</ImageLoaded>
+				<ImageLoaded condition="contains any">.xla</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=T1090.003,Technique=Proxy: Multi-hop Proxy,Tactic=Defense Evasion,Level=4,Alert=Ransomware detected tor library,Risk=100" groupRelation="and">
+				<ImageLoaded condition="contains">tor-lib.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=Cred Dumping,Risk=90" groupRelation="and">
+				<ImageLoaded condition="is any">C:\Windows\System32\WinSCard.dll;C:\Windows\System32\cryptdll.dll;C:\Windows\System32\hid.dll;C:\Windows\System32\samlib.dll;C:\Windows\System32\vaultcli.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=Mimikatz Cred Dumping,Risk=100" groupRelation="and">
+				<Image condition="image">rundll32.exe</Image>
+				<ImageLoaded condition="contains all">vaultcli.dll;wlanapi.dll</ImageLoaded>
+				<ImageLoaded condition="excludes">combase.dll</ImageLoaded>
+				<ImageLoaded condition="excludes">cryptdll.dll</ImageLoaded>
+				<ImageLoaded condition="excludes">imm32.dll</ImageLoaded>
+				<ImageLoaded condition="excludes">logoncli.dll</ImageLoaded>
+				<ImageLoaded condition="excludes">netapi32.dll</ImageLoaded>
+				<ImageLoaded condition="excludes">ntasn1.dll</ImageLoaded>
+				<ImageLoaded condition="excludes">ntdsapi.dll</ImageLoaded>
+				<ImageLoaded condition="excludes">samlib.dll</ImageLoaded>
+				<ImageLoaded condition="excludes">shcore.dll</ImageLoaded>
+				<ImageLoaded condition="excludes">srvcli.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ImageLoaded condition="contains all">odbc32.dll;winhttp.dll;netapi32.dll;SHLWAPI.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">C:\Windows\Explorer.EXE</Image>
+				<ImageLoaded condition="is">C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="begin with">C:\ProgramData\</Image>
+				<ImageLoaded condition="begin with">C:\ProgramData\</ImageLoaded>
+				<ImageLoaded condition="end with">.exe</ImageLoaded>
+				<Company condition="excludes">Adobe</Company>
+				<Image condition="excludes">C:\ProgramData\Lenovo\</Image>
+				<ImageLoaded condition="excludes">C:\ProgramData\Microsoft\Windows Defender\</ImageLoaded>
+				<ImageLoaded condition="excludes">C:\ProgramData\sysmon\sysmon64.exe</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<ImageLoaded condition="contains any">C:\Users\Default\;C:\Users\Public\</ImageLoaded>
+				<ImageLoaded condition="end with">.exe</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=T1195,Technique=Supply Chain Compromise,Tactic=Initial Access,Level=4,Alert=Solarwinds/FireEye sunburst image hashes,Risk=100" groupRelation="and">
+				<Hashes condition="contains any">56ceb6d0011d87b6e4d7023d7ef85676;4f2eb62fa529c0283b28d05ddd311fae;b91ce2fa41029f6955bff20079468448;b91ce2fa41029f6955bff20079468448;846e27a652a5e1bfbd0ddd38a16dc865;2c4a910a1299cdae2a4e55988a2f102e</Hashes><!-- exclude non executable files -->
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">C:\Windows\System32\svchost.exe</Image>
+				<Signed condition="is">false</Signed>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<SignatureStatus condition="is">Revoked</SignatureStatus>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<SignatureStatus condition="is">Expired</SignatureStatus>
+			</Rule>
+			<Rule name="Level=4,Alert=HTA Exec with IE JS Engine AMSI Bypass" groupRelation="and">
+				<ImageLoaded condition="end with">jscript9.dll</ImageLoaded>
+				<Image condition="image">mshta.exe</Image>
+			</Rule>
+			<ImageLoaded condition="end with">scrobj.dll</ImageLoaded>
+			<ImageLoaded condition="end with">crypt0.dll</ImageLoaded>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=Wireless Credential Dumping" groupRelation="and">
+				<ImageLoaded condition="end with">C:\Windows\System32\wlanapi.dll</ImageLoaded>
+				<Image condition="excludes">C:\Program Files\NVIDIA Corporation\NVIDIA GeForce Experience\NVIDIA Share.exe</Image>
+				<Image condition="excludes">C:\Program Files\NVIDIA Corporation\NVIDIA GeForce Experience\NVIDIA Share.exe</Image>
+				<Image condition="excludes">C:\Program Files\WindowsApps\MicrosoftWindows.Client.WebExperience</Image>
+				<Image condition="excludes">C:\Windows\ImmersiveControlPanel\SystemSettings.exe</Image>
+				<Image condition="excludes">C:\Windows\ImmersiveControlPanel\SystemSettings.exe</Image>
+				<Image condition="excludes">C:\Windows\System32\AppHostRegistrationVerifier.exe</Image>
+				<Image condition="excludes">C:\Windows\System32\CompatTelRunner.exe</Image>
+				<Image condition="excludes">C:\Windows\System32\DeviceCensus.exe</Image>
+				<Image condition="excludes">C:\Windows\System32\DriverStore\FileRepository\</Image>
+				<Image condition="excludes">C:\Windows\System32\LogonUI.exe</Image>
+				<Image condition="excludes">C:\Windows\System32\MoNotificationUx.exe</Image>
+				<Image condition="excludes">C:\Windows\System32\SystemSettingsBroker.exe</Image>
+				<Image condition="excludes">C:\Windows\System32\dxgiadaptercache.exe</Image>
+				<Image condition="excludes">C:\Windows\System32\netsh.exe</Image>
+				<Image condition="excludes">C:\Windows\System32\wlanext.exe</Image>
+				<Image condition="excludes">C:\Windows\UUS\amd64\MoUsoCoreWorker.exe</Image>
+				<Image condition="excludes">C:\Windows\WinSxS\amd64_microsoft-windows-servicingstack_</Image>
+				<Image condition="excludes">C:\Windows\explorer.exe</Image>
+			</Rule>
+			<ImageLoaded name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\Microsoft.NET\assembly\GAC_MSIL</ImageLoaded>
+		</ImageLoad>
+	</RuleGroup>
+	<RuleGroup name="RG=Image Load Excludes" groupRelation="or">
+		<ImageLoad onmatch="exclude">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains">\Microsoft Office\</Image>
+				<ImageLoaded condition="end with">\mscorlib.ni.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains">\Microsoft Office\</Image>
+				<ImageLoaded condition="end with">\sppc.dll</ImageLoaded>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">C:\Windows\System32\svchost.exe</Image>
+				<Signed condition="is">true</Signed>
+			</Rule>
+			<!--Universal Exclusions: Be Careful-->
+			<Company condition="contains">Fortinet</Company>
+			<Company condition="contains">Lenovo</Company>
+			<Company condition="contains">Sophos</Company>
+			<Image condition="end with">mscorsvw.exe</Image>
+			<Image condition="image">C:\Program Files (x86)\Microsoft Office\root\Office15\officebackgroundtaskhandler.exe</Image>
+			<Image condition="image">C:\Program Files (x86)\Microsoft Office\root\Office16\officebackgroundtaskhandler.exe</Image>
+			<Image condition="image">C:\Program Files\Microsoft Office\root\Office15\officebackgroundtaskhandler.exe</Image>
+			<Image condition="image">C:\Program Files\Microsoft Office\root\Office16\officebackgroundtaskhandler.exe</Image>
+			<Image condition="image">C:\Windows\SysWOW64\SearchProtocolHost.exe</Image>
+			<Image condition="image">C:\Windows\System32\InstallAgentUserBroker.exe</Image>
+			<Image condition="image">C:\Windows\System32\RuntimeBroker.exe</Image>
+			<Image condition="image">C:\Windows\System32\SearchIndexer.exe</Image>
+			<Image condition="image">C:\Windows\System32\SettingSyncHost.exe</Image>
+			<Image condition="image">C:\Windows\System32\backgroundTaskHost.exe</Image>
+			<Image condition="image">C:\Windows\System32\sppsvc.exe</Image>
+			<Image condition="image">C:\Windows\System32\taskhost.exe</Image>
+			<Image condition="image">C:\Windows\System32\taskhostw.exe</Image>
+			<Image condition="image">C:\Windows\SystemApps\Microsoft.AAD.BrokerPlugin_cw5n1h2txyewy\Microsoft.AAD.BrokerPlugin.exe</Image>
+			<Image condition="image">C:\Windows\SystemApps\Microsoft.Windows.Cortana_cw5n1h2txyewy\SearchUI.exe</Image>
+			<Image condition="image">HxTsr.exe</Image>
+			<Image condition="image">SearchUI.exe</Image>
+			<ImageLoaded condition="contains">C:\Program Files (x86)\Common Files\BIExcelFunctions1.1\32bit\Sage.</ImageLoaded>
+			<ImageLoaded condition="contains">C:\Windows\Microsoft.NET\assembly\GAC_MSIL\Pfx.</ImageLoaded>
+			<ImageLoaded condition="is">C:\Program Files (x86)\Adobe\Acrobat 10.0\Acrobat\Adist64.dll</ImageLoaded>
+			<ImageLoaded condition="is">C:\Program Files (x86)\Microsoft Office\Office15\Library\Analysis\ANALYS32.XLL</ImageLoaded>
+			<ImageLoaded condition="is">C:\Program Files (x86)\Microsoft Office\Office16\Library\Analysis\ANALYS32.XLL</ImageLoaded>
+			<ImageLoaded condition="is">C:\Program Files\Microsoft Office\Office15\Library\Analysis\ANALYS32.XLL</ImageLoaded>
+			<ImageLoaded condition="is">C:\Program Files\Microsoft Office\Office16\Library\Analysis\ANALYS32.XLL</ImageLoaded>
+			<ImageLoaded condition="is">C:\Windows\SysWOW64\sppc.dll</ImageLoaded>
+			<ImageLoaded condition="is">Microsoft.Office.Interop.VisOcx.dll</ImageLoaded>
+			<ImageLoaded condition="is">Microsoft.Office.Interop.Word.dll</ImageLoaded>
+			<ImageLoaded condition="is">Microsoft.Vbe.Interop.dll</ImageLoaded>
+			<ImageLoaded condition="is">OFFICE.DLL</ImageLoaded>
+		</ImageLoad>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 8 : REMOTE THREAD CREATED [CreateRemoteThread]-->
+	<RuleGroup name="RG=CreateRemoteThread Include Group" groupRelation="or">
+		<CreateRemoteThread onmatch="include">
+			<!--Custom Rules-->
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping from lsass,Risk=100" groupRelation="and">
+				<StartAddress condition="is">0x001A0000</StartAddress>
+				<TargetImage condition="image">c:\windows\system32\lsass.exe</TargetImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privledge Escalation,Level=4,Alert=CreateRemoteThread with msiexec,Risk=100" groupRelation="and">
+				<SourceImage condition="contains any">msiexec.exe</SourceImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion,Level=0,Desc=Remote Thread Injection Targetting Web Browser,Risk=70" groupRelation="and">
+				<TargetImage condition="contains any">chrome.exe;firefox.exe;edge.exe;browser_broker.exe;iexplore.exe</TargetImage>
+			</Rule>
+			<Rule name="Attack=T1003,Tactic=Credential Access,Technique=OS Credential Dumping,Level=0,Desc=LSASS Credential dumping,Risk=70" groupRelation="and">
+				<StartAddress condition="is">0x001A0000</StartAddress>
+				<TargetImage condition="image">c:\windows\system32\lsass.exe</TargetImage>
+			</Rule>
+			<Rule name="Attack=T1003,Tactic=Credential Access,Technique=OS Credential Dumping,Level=0,Desc=Rundll32 LSASS Credential dumping,Risk=70" groupRelation="and">
+				<TargetImage condition="image">c:\windows\system32\lsass.exe</TargetImage>
+				<SourceImage condition="image">c:\windows\system32\rundll32.exe</SourceImage>
+			</Rule>
+			<Rule name="Attack=T1546.012,Technique=Event Triggered Execution: Image File Execution Options Injection,Tactic=Persistence,Level=4,Alert=Remote Thread Process debugging detected,Risk=30" groupRelation="and">
+				<StartFunction condition="contains">DbgUiRemoteBreakin</StartFunction>
+				<TargetImage condition="excludes">nacl64.exe</TargetImage>
+			</Rule>
+			<Rule name="Attack=T1546.012,Technique=Event Triggered Execution: Image File Execution Options Injection,Tactic=Persistence,Level=0,Desc=Remote Query Debug info,Risk=30" groupRelation="and">
+				<StartFunction condition="contains">QueryProcessDebugInformationRemote</StartFunction>
+				<TargetImage condition="excludes">nacl64.exe</TargetImage>
+			</Rule>
+			<Rule name="Attack=T1546.012,Technique=Event Triggered Execution: Image File Execution Options Injection,Tactic=Persistence,Tactic=Defense Evasion,Level=0,Desc=Query Debug info 2,Risk=30" groupRelation="and">
+				<StartFunction condition="contains">isdebuggerpresent</StartFunction>
+				<TargetImage condition="excludes">nacl64.exe</TargetImage>
+			</Rule>
+			<Rule name="Attack=T1546.012,Technique=Process Debugging Detected,Tactic=Defense Evasion,Level=3,Alert=Process Debug of active Process,Risk=30" groupRelation="and">
+				<StartFunction condition="contains">DebugActiveProcess</StartFunction>
+				<TargetImage condition="excludes">nacl64.exe</TargetImage>
+			</Rule>
+			<Rule name="Attack=T1055.001,Technique=Process Injection: Dynamic-link Library Injection,Tactic=Defense Evasion,Level=3,Alert=LoadLibrary DLL Injection,Risk=70" groupRelation="and">
+				<StartFunction condition="contains">LoadLibrary</StartFunction>
+				<SourceImage condition="excludes">C:\Program Files\Bitdefender\Endpoint Security\EPSecurityService.exe</SourceImage>
+				<SourceImage condition="excludes">C:\Program Files\NVIDIA Corporation\Display.NvContainer\NVDisplay.Container.exe</SourceImage>
+				<SourceImage condition="excludes">C:\Windows\ImmersiveControlPanel\SystemSettings.exe</SourceImage>
+				<SourceImage condition="excludes">C:\Windows\System32\DriverStore\FileRepository\</SourceImage>
+				<SourceImage condition="excludes">C:\Windows\System32\igfxEM.exe</SourceImage>
+				<SourceImage condition="excludes">C:\Windows\System32\igfxHK.exe</SourceImage>
+				<SourceImage condition="excludes">Enterprise\Common7\IDE\devenv.exe</SourceImage>
+				<TargetImage condition="excludes">C:\Program Files (x86)\ASUS\ROG Live Service\FileOperator.exe</TargetImage>
+				<SourceImage condition="excludes all">C:\ProgramData\Microsoft\Windows Defender\Platform\;\MsMpEng.exe</SourceImage>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion,Level=0,Desc=CreateFileMapping,Risk=70" groupRelation="and">
+				<StartFunction condition="contains any">CreateFileMapping;MapViewOfFile</StartFunction>
+			</Rule>			
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion,Level=0,Desc=LdrLoadDll DLL Injection,Risk=70" groupRelation="and">
+				<StartFunction condition="contains any">LdrLoadDll</StartFunction>
+			</Rule>
+			<Rule name="Attack=T1106,Technique=Native API,Tactic=Execution,Level=0,Desc=Crypt API Usage" groupRelation="and">
+				<StartFunction condition="contains any">CryptAcquireContextA;CryptDecodeObjectEx;CryptImportPublicKeyInfo;CryptEncrypt;CryptGenKey;CryptDecrypt;CryptStringToBinary;CryptBinaryToString;CryptImportKey</StartFunction>
+			</Rule>
+			<Rule name="Attack=T1115,Technique=Clipboard Data,Tactic=Collection,Level=0,Desc=Clipboard Usage Detected" groupRelation="and">
+				<SourceImage condition="image">c:\windows\system32\csrss.exe</SourceImage>
+				<StartFunction condition="contains">CrtlRoutine</StartFunction>
+			</Rule>
+			<StartAddress name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion,Level=4,Alert=Cobalt Strike Detected 1,Risk=100" condition="end with">0B80</StartAddress>
+			<StartAddress name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion,Level=4,Alert=Cobalt Strike Detected 2,Risk=100" condition="end with">0C7C</StartAddress>
+			<StartAddress name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion,Level=4,Alert=Cobalt Strike Detected 3,Risk=100" condition="end with">0C88</StartAddress>
+			<TargetImage name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion,Level=0,Desc=Remote Desktop injection,Risk=30" condition="image">c:\windows\system32\mstsc.exe</TargetImage>
+			<Rule name="Alert=Potentially Detect EtwEventWrite Tampering with remote threads" groupRelation="and">
+				<StartModule condition="is">C:\WINDOWS\SYSTEM32\ntdll.dll</StartModule>
+				<StartFunction condition="contains">EtwEventWrite</StartFunction>
+			</Rule>
+		</CreateRemoteThread>
+	</RuleGroup>
+	<RuleGroup name="RG=CreateRemoteThread Exclude Group" groupRelation="or">
+		<CreateRemoteThread onmatch="exclude">
+			<!--COMMENT: Exclude mostly-safe sources and log anything else.-->
+			<SourceImage condition="image">C:\Windows\SysWOW64\wbem\WmiPrvSE.exe</SourceImage>
+			<SourceImage condition="image">C:\Windows\system32\audiodg.exe</SourceImage>
+			<SourceImage condition="image">C:\Windows\system32\services.exe</SourceImage>
+			<SourceImage condition="image">C:\Windows\system32\svchost.exe</SourceImage>
+			<SourceImage condition="image">C:\Windows\system32\wbem\WmiPrvSE.exe</SourceImage>
+			<SourceImage condition="image">C:\Windows\system32\wininit.exe</SourceImage>
+			<SourceImage condition="image">C:\Windows\system32\winlogon.exe</SourceImage>
+		</CreateRemoteThread>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 9 : RAW DISK ACCESS [RawAccessRead]-->
+	<RuleGroup name="RG=RawAccessRead Include Group" groupRelation="or">
+		<RawAccessRead onmatch="include">
+		</RawAccessRead>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 10 : INTER-PROCESS ACCESS [ProcessAccess]-->
+	<RuleGroup name="RG=ProcessAccess Include Group" groupRelation="or">
+		<ProcessAccess onmatch="include">
+			<!--Custom Rules-->
+			<Rule name="Attack=T1059.005,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=CSShellExecute_ExecuteAssoc,Risk=30" groupRelation="and">
+				<CallTrace condition="contains">C:\Windows\System32\SHELL32.dll+9b5bd</CallTrace>
+				<TargetImage condition="excludes">\LocalBridge.exe</TargetImage>
+			</Rule>
+			<Rule name="Attack=T1059.005,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=WSHellExec,Risk=50" groupRelation="and">
+				<CallTrace condition="contains any">C:\Windows\System32\wshom.ocx+c8a0;C:\Windows\System32\wshom.ocx+c39d</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1047.005,Technique=Windows Management Instrumentation,Tactic=Execution,Level=0,Desc=CWbemProviderGlueExecMethodAsync,Risk=50" groupRelation="and">
+				<CallTrace condition="contains">C:\Windows\SYSTEM32\framedynos.dll+2cb3e</CallTrace>
+				<TargetImage condition="excludes any">C:\Windows\system32\SgrmBroker.exe;C:\Windows\system32\SecurityHealthService.exe;C:\ProgramData\Microsoft\Windows Defender\platform\;C:\Windows\system32\services.exe;C:\Windows\system32\wininit.exe;C:\Windows\system32\sppsvc.exe;C:\Windows\System32\smss.exe;C:\Windows\system32\csrss.exe;C:\Windows\System32\svchost.exe</TargetImage>
+			</Rule>
+			<Rule name="Attack=T1047.005,Technique=Windows Management Instrumentation,Tactic=Execution,Level=0,Desc=ProviderExecMethod 1,Risk=60" groupRelation="and">
+				<CallTrace condition="contains">C:\Windows\SYSTEM32\framedynos.dll+2b496</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1003.001,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=MiniDumpWriteDump,Risk=50" groupRelation="and">
+				<CallTrace condition="contains">C:\Windows\SYSTEM32\dbgcore.DLL+6cfb</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1003.001,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=PssCaptureSnapShot,Risk=50" groupRelation="and">
+				<CallTrace condition="contains">C:\Windows\System32\KernelBase.dll+de67e</CallTrace>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<CallTrace condition="contains">ntdll.dll+a0044</CallTrace>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<CallTrace condition="contains any">clr.dll+6c23;clr.dll+6b38</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1055,Tactic=Defense Evasion,Technique=Process Injection,Level=0,Desc=Suspicious In-Memory Module Execution 1,Risk=30" groupRelation="and">
+				<CallTrace condition="contains all">C:\Windows\\SYSTEM32\ntdll.dll+;|C:\Windows\System32\KERNELBASE.dll+;|UNKNOWN(</CallTrace>
+				<CallTrace condition="end with">)</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1055,Tactic=Defense Evasion,Technique=Process Injection,Level=0,Desc=Suspicious In-Memory Module Execution 2,Risk=30" groupRelation="and">
+				<CallTrace condition="contains all">"UNKNOWN(;)|UNKNOWN(</CallTrace>
+				<CallTrace condition="end with">)</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1055,Tactic=Defense Evasion,Technique=Process Injection,Level=0,Desc=Suspicious In-Memory Module Execution 3,Risk=30" groupRelation="and">
+				<CallTrace condition="contains all">"UNKNOWN</CallTrace>
+				<GrantedAccess condition="contains any">0x1F0FFF;0x1F1FFF;0x143A;0x1410;0x1010;0x1F2FFF;0x1F3FFF;0x1FFFFF</GrantedAccess>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion,Level=0,Desc=Office Macro Injection Detected,Risk=100" groupRelation="and">
+				<SourceImage condition="contains all">C:\Program Files;\Microsoft Office\Root\Office</SourceImage>
+				<CallTrace condition="contains">\Microsoft Shared\VBA</CallTrace>
+				<TargetImage condition="excludes">C:\Program Files (x86)\Intuit\</TargetImage>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=LSASS Credential Access,Risk=70" groupRelation="and">
+				<TargetImage condition="image">C:\Windows\system32\lsass.exe</TargetImage>
+				<GrantedAccess>0x1FFFFF</GrantedAccess>
+				<CallTrace condition="contains">UNKNOWN</CallTrace>
+				<CallTrace condition="excludes">WmiPerfClass.dll</CallTrace>
+				<SourceImage condition="excludes any">C:\Windows\sysWOW64\wbem\wmiprvse.exe;C:\Windows\system32\wbem\wmiprvse.exe;C:\Program Files\VMware\VMware Tools\vmtoolsd.exe;C:\Program Files (x86)\VMware\VMware Tools\vmtoolsd.exe;WmiPerfClass.dll;C:\Program Files (x86)\Adobe\Adobe Sync\CoreSync\customhook\CoreSyncCustomHook.exe;C:\Program Files\Adobe\Adobe Sync\CoreSync\customhook\CoreSyncCustomHook.exe;C:\Program Files (x86)\Common Files\Adobe</SourceImage>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=Mimikatz through Windows Remote Management,Risk=100" groupRelation="and">
+				<TargetImage condition="image">C:\Windows\system32\lsass.exe</TargetImage>
+				<SourceImage condition="image">C:\Windows\system32\wsmprovhost.exe</SourceImage>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=LSASS process access by LaZagne,Risk=100" groupRelation="and">
+				<TargetImage condition="image">C:\Windows\system32\lsass.exe</TargetImage>
+				<GrantedAccess>0x1FFFFF</GrantedAccess>
+				<CallTrace condition="contains all">python27.dll;_ctypes.pyd;KERNELBASE.dll;ntdll.dll</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=LSASS process access by Mimikatz,Risk=100" groupRelation="and">
+				<TargetImage condition="image">C:\Windows\system32\lsass.exe</TargetImage>
+				<CallTrace condition="begin with">C:\Windows\SYSTEM32\ntdll.dll+4595c|C:\Windows\system32\KERNELBASE.dll+8185</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=LSASS Cobalt Strike Monitor,Risk=70" groupRelation="and">
+				<TargetImage condition="image">C:\Windows\system32\lsass.exe</TargetImage>
+				<CallTrace condition="begin with">C:\WINDOWS\SYSTEM32\ntdll.dll+</CallTrace>
+				<CallTrace condition="end with">)</CallTrace>
+				<CallTrace condition="contains all">|C:\WINDOWS\System32\KERNELBASE.dll+;|UNKNOWN(</CallTrace>
+				<CallTrace condition="excludes any">wow64.dll;)|C;Exchange.Diagnostics;Microsoft.Exchange</CallTrace>
+				<SourceImage condition="excludes any">C:\Program Files\Bitdefender\Endpoint Security\EPSecurityService.exe;c:\windows\system32\inetsrv\w3wp.exe;MSExchangeHMHost.exe;C:\Windows\sysWOW64\wbem\wmiprvse.exe</SourceImage>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Rubeus Mimikatz Like Detection,Risk=70" groupRelation="and">
+				<TargetImage condition="image">C:\Windows\system32\winlogon.exe</TargetImage>
+				<GrantedAccess>0x1F3FFF</GrantedAccess>
+				<CallTrace condition="contains any">C:\Windows\Microsoft.NET;UNKNOWN</CallTrace>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<SourceImage condition="end with">.exe</SourceImage>
+				<TargetImage condition="contains any">C:\Windows\sysmon64.exe;C:\Windows\sysmon64.exe</TargetImage>
+				<GrantedAccess>0x1C00</GrantedAccess>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=LSASS Access,Risk=20" groupRelation="and">
+				<TargetImage condition="image">C:\Windows\system32\lsass.exe</TargetImage>
+				<GrantedAccess>0x1F1FFF</GrantedAccess>
+				<CallTrace condition="contains">UNKNOWN</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=LSASS Access 2,Risk=20" groupRelation="and">
+				<TargetImage condition="image">C:\Windows\system32\lsass.exe</TargetImage>
+				<GrantedAccess>0x1010</GrantedAccess>
+				<CallTrace condition="contains">UNKNOWN</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=LSASS Access 3,Risk=20" groupRelation="and">
+				<TargetImage condition="image">C:\Windows\system32\lsass.exe</TargetImage>
+				<GrantedAccess>0x143A</GrantedAccess>
+				<CallTrace condition="contains">UNKNOWN</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=LSASS Memory Dump,Risk=100" groupRelation="and">
+				<TargetImage condition="image">C:\Windows\system32\lsass.exe</TargetImage>
+				<GrantedAccess>0x1fffff</GrantedAccess>
+				<CallTrace condition="contains any">dbghelp.dll;dbgcore.dll</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=0,Desc=Process access with dbghelp,Risk=30" groupRelation="and">
+				<CallTrace condition="contains any">dbghelp.dll;dbgcore.dll</CallTrace>
+				<TargetImage condition="excludes">C:\Windows\system32\lsass.exe</TargetImage>
+				<SourceImage condition="excludes">C:\wfx32\</SourceImage>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<SourceImage condition="image">powershell.exe</SourceImage>
+				<TargetImage condition="excludes any">C:\Programdata\sysmon\sysmon64.exe;C:\Programdata\sysmon\sysmon.exe;C:\Windows\sysmon.exe;C:\Windows\sysmon64.exe;\dismhost.exe</TargetImage>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<CallTrace condition="contains">getasynckeystate</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1088,Technique=UAC Bypass,Tactic=Defense Evasion/Privilege Escalation,Level=0,Desc=CMSTP UAC Bypass" groupRelation="and">
+				<CallTrace condition="contains">cmlua.dll</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1086,Technique=PowerShell,Tactic=Execution,Level=3,Alert=Powershell without Powershell,Risk=30" groupRelation="and">
+				<CallTrace condition="contains">System.Management.Automation</CallTrace>
+				<CallTrace condition="excludes">C:\ProgramData\Microsoft\Windows Defender\platform\</CallTrace>
+				<CallTrace condition="excludes">ctiuser.dll</CallTrace>
+				<SourceImage condition="is not">C:\Program Files\Citrix\ConfigSync\ConfigSyncRun.exe</SourceImage>
+				<SourceImage condition="is not">C:\Program Files\Microsoft\Exchange Server\V14\bin\ExSetupUI.exe</SourceImage>
+				<SourceImage condition="is not">C:\Program Files\Microsoft\Exchange Server\V15\bin\ExSetupUI.exe</SourceImage>
+				<SourceImage condition="is not">C:\Program Files\Microsoft\Exchange Server\V16\bin\ExSetupUI.exe</SourceImage>
+				<SourceImage condition="is not">C:\Windows\SysWOW64\sdiagnhost.exe</SourceImage>
+				<SourceImage condition="is not">C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</SourceImage>
+				<SourceImage condition="is not">C:\Windows\Temp\ExchangeSetup\ExSetupUI.exe</SourceImage>
+				<SourceImage condition="is not">C:\system32\WindowsPowerShell\v1.0\PowerShell_ISE.exe</SourceImage>
+				<TargetImage condition="is not">C:\Program Files\Microsoft Azure Active Directory Connect\AzureADConnect.exe</TargetImage>
+				<TargetImage condition="is not">C:\Windows\system32\HOSTNAME.EXE</TargetImage>
+				<TargetImage condition="is not">C:\Windows\system32\ROUTE.exe</TargetImage>
+				<TargetImage condition="is not">C:\Windows\system32\query.exe</TargetImage>
+				<TargetImage condition="is not">MsMpEng.exe</TargetImage>
+			</Rule>
+			<Rule name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=3,Alert=Kaodic credential access detected,Risk=100" groupRelation="and">
+				<TargetImage condition="image">C:\Windows\system32\lsass.exe</TargetImage>
+				<CallTrace condition="contains">comsvcs.dll</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1059,Technique=Scripting,Tactic=Execution,Level=3,Alert=Office Macro Execution VBE7,Risk=80" groupRelation="and">
+				<CallTrace condition="contains any">VBE7.dll;VBEUI.DLL;VBE7INTL.DLL</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1059,Technique=Scripting,Tactic=Execution,Level=3,Alert=Office Macro Execution VBE6,Risk=80" groupRelation="and">
+				<CallTrace condition="contains any">VBE6.dll;VBEUI.DLL;VBE6INTL.DLL</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1059,Technique=Scripting,Tactic=Execution,Level=3,Alert=verclsid Office Execution,Risk=80" groupRelation="and">
+				<SourceImage condition="contains">Office</SourceImage>
+				<TargetImage condition="contains">verclsid.exe</TargetImage>
+				<CallTrace condition="contains any">VBE7.dll;VBEUI.DLL;VBE7INTL.DLL</CallTrace>
+				<CallTrace condition="contains any">|UNKNOWN(</CallTrace>
+				<GrantedAccess condition="contains">0x1FFFFF</GrantedAccess>
+			</Rule>
+			<Rule name="Attack=T1059.005,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=CreateProcessW,Risk=70" groupRelation="and">
+				<SourceImage condition="contains">C:\Program Files\Microsoft Office\Root\Office</SourceImage>
+				<CallTrace condition="contains">C:\Windows\System32\KERNELBASE.dll+76516</CallTrace>
+			</Rule>
+			<Rule name="Attack=T1059.005,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=CSShellExecute_DoExecute,Risk=30" groupRelation="and">
+				<CallTrace condition="contains" >C:\Windows\System32\SHELL32.dll+ae3b9</CallTrace>
+				<TargetImage condition="excludes">C:\WINDOWS\system32\sihost.exe</TargetImage>
+				<TargetImage condition="excludes">C:\Program Files\WindowsApps\Microsoft.MicrosoftOfficeHub</TargetImage>
+			</Rule>
+			<CallTrace name="Level=4,Alert=CobaltStrike BOF using OpenProcess/NtOpenProcess" condition="begin with">UNKNOWN</CallTrace>
+			<Rule name="Level=4,Alert=Typical ProcessAccess Pattern of CobaltStrike BOF" groupRelation="and">
+				<CallTrace condition="contains">|UNKNOWN(</CallTrace>
+				<CallTrace condition="begin with">C:\WINDOWS\SYSTEM32\ntdll.dll+</CallTrace>
+				<CallTrace condition="contains">|C:\WINDOWS\System32\KERNELBASE.dll+</CallTrace>
+				<CallTrace condition="end with">)</CallTrace>
+				<GrantedAccess condition="contains any">0x1028;0x1fffff</GrantedAccess>
+				<SourceImage condition="excludes any">C:\Program Files\SmartGit\bin\;C:\Program Files (x86)\ASUS\Update\;C:\Program Files (x86)\Razer\Synapse3\Service\Razer Synapse Service.exe;C:\Program Files (x86)\Citrix\ICA Client\Receiver\UpdaterService.exe;C:\WINDOWS\SysWOW64\config\systemprofile\Citrix\UpdaterBinaries\;C:\Program Files\Mozilla Firefox\firefox.exe;C:\Program Files\SmartGit\git\</SourceImage>
+			</Rule>
+			<Rule name="Level=3,Alert=Potential MalDoc Behavior" groupRelation="and">
+				<SourceImage condition="contains any">winword.exe;excel.exe;powerpnt.exe</SourceImage>
+				<CallTrace condition="contains all">:\Windows\Microsoft.NET\Framework64\v2.;UNKNOWN</CallTrace>
+			</Rule>
+			<Rule name="Level=4,Alert=Potential Metasploit Process Migration" groupRelation="and">
+				<CallTrace condition="contains">UNKNOWN</CallTrace>
+				<GrantedAccess condition="contains">0x147a</GrantedAccess>
+			</Rule>
+			<Rule name="Attack=T1562.002,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=SysmonEnte Detection,Level=4,Risk=100" groupRelation="and">
+				<TargetImage condition="contains any">C:\Windows\Sysmon64.exe;C:\Windows\Sysmon.exe</TargetImage>
+				<SourceImage condition="is not">C:\WINDOWS\system32\wbem\wmiprvse.exe</SourceImage>
+				<SourceImage condition="is not">C:\Program Files (x86)\ASUS\Update\AsusUpdate.exe</SourceImage>
+				<SourceImage condition="excludes all">C:\ProgramData\Microsoft\Windows Defender\Platform\;\MsMpEng.exe;C:\Program Files (x86)\Microsoft\EdgeUpdate\MicrosoftEdgeUpdate.exe;C:\Program Files (x86)\Google\Update\GoogleUpdate.exe</SourceImage>
+				<GrantedAccess condition="contains">0x1400</GrantedAccess>
+			</Rule>
+			<!-- PROCESS_SUSPEND_RESUME + PROCESS_VM_WRITE: possible memory injection -->
+			<GrantedAccess name="Attack=T1093,Technique=Process Hollowing,Tactic=Defense Evasion,Level=4,Alert=Process Hollowing Detected,Risk=100">0x0800</GrantedAccess>
+			<!-- PROCESS_SUSPEND_RESUME -->
+			<GrantedAccess name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping from Memory indicator">0x0810</GrantedAccess>
+			<!-- PROCESS_SUSPEND_RESUME + PROCESS_VM_READ: possible memory dump to extract sensitive information -->
+			<GrantedAccess name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=0,Desc=Possible Memory Dump,Risk=70">0x0820</GrantedAccess>
+			<!-- PROCESS_SUSPEND_RESUME -->
+			<GrantedAccess name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping from Memory indicator,Risk=70">0x810</GrantedAccess>
+			<!-- PROCESS_SUSPEND_RESUME + PROCESS_VM_READ: possible memory dump to extract sensitive information -->
+			<GrantedAccess name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Risk=70">0x820</GrantedAccess>
+			<SourceImage name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">cscript.exe</SourceImage>
+			<SourceImage name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">wscript.exe</SourceImage>
+			<SourceImage condition="end with">jjs.exe</SourceImage>
+			<CallTrace name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping from Memory indicator,Risk=100" condition="contains">dump</CallTrace>
+			<CallTrace name="Attack=T1003,Technique=Credential Dumping,Tactic=Credential Access,Level=4,Alert=Credential Dumping from Memory indicator,Risk=100" condition="contains">mimikatz</CallTrace>
+			<CallTrace name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">CorperfmontExt.dll</CallTrace>
+		</ProcessAccess>
+	</RuleGroup>
+	<RuleGroup name="RG=ProcessAccess Exclude Group" groupRelation="or">
+		<ProcessAccess onmatch="exclude">
+			<Rule name="wmi accessing lsass" groupRelation="and">
+				<SourceImage condition="image">wmiprvse.exe</SourceImage>
+				<TargetImage condition="image">lsass.exe</TargetImage>
+			</Rule>
+			<Rule name="lsass accessing winlogon" groupRelation="and">
+				<SourceImage condition="image">lsass.exe</SourceImage>
+				<TargetImage condition="image">winlogon.exe</TargetImage>
+			</Rule>
+			<!-- These binaries appear to access lsass legitimately -->
+			<Rule name="legitimate lsass access" groupRelation="and">
+				<TargetImage condition="contains">lsass.exe</TargetImage>
+				<SourceImage condition="excludes any">C:\Windows\system32\w32tm.exe;C:\Windows\System32\ping.exe;C:\Windows\System32\net.exe;C:\Windows\System32\net1.exe;C:\Windows\SYSTEM32\HOSTNAME.EXE;C:\Programdata\sysmon\sysmon.exe;C:\Programdata\sysmon\sysmon64.exe;C:\Program Files\Windows Defender\MsMpEng.exe;C:\Program Files (x86)\BeAnywhere Support Express\;C:\Program Files (x86)\CheckPoint\;C:\Program Files (x86)\Common Files\Intuit\QuickBooks\;C:\Program Files (x86)\Fortinet\;C:\Program Files (x86)\Trend Micro\;C:\Program Files\Adobe\Adobe Creative Cloud Experience\;C:\Program Files\CheckPoint\;C:\Program Files\Fortinet\;C:\Program Files\Realtek;C:\Program Files\Trend Micro\;C:\ProgramData\Microsoft\Windows Defender\platform\;C:\Program Files (x86)\Lenovo\;snmpd.exe;taskmgr;:\Windows\System32\smss.exe;:\Windows\system32\wininit.exe;\Bin\FMS.exe; <!-- Exchange Process -->\EMET_GUI.exe;\EMET_Service.exe;\Google\Update\GoogleUpdate.exe;\RAAGTAPP.EXE;\controls\cef\ConnectWise.exe;C:\Program Files (x86)\Sophos\Sophos Anti-Virus\SavService.exe;C:\Program Files\Hewlett-Packard\AMS\service\hpqams.exe;C:\Program Files\Intel\SUR\WILLAMETTE\ESRV\esrv_svc.exe;C:\Program Files\VMware\VMware Tools\vmtoolsd.exe;C:\Program Files\Windows Defender\MsMpEng.exe;C:\WINDOWS\system32\WerFault.exe;C:\WINDOWS\system32\taskkill.exe;C:\Windows\SysWOW64\WerFault.exe;C:\Windows\System32\snmp.exe;C:\Windows\system32\msiexec.exe;C:\Windows\system32\spoolsv.exe;C:\Windows\system32\svchost.exe</SourceImage>
+			</Rule>
+			<!-- These binaries get or access processes running .NET -->
+			<SourceImage condition="end with">:\Windows\system32\sppsvc.exe</SourceImage>
+			<SourceImage condition="end with">:\Windows\system32\sdiagnhost.exe</SourceImage>
+			<!-- In testing a common false-positive is memory space that DLLS would be expected to mapped to. -->
+			<CallTrace condition="contains">UNKNOWN(00007F</CallTrace>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<CallTrace condition="not begin with">C:\Windows\SYSTEM32\ntdll.dll</CallTrace>  
+				<CallTrace condition="not begin with">C:\Windows\SYSTEM32\win32u.dll</CallTrace>
+				<CallTrace condition="not begin with">C:\Windows\SYSTEM32\wow64win.dll</CallTrace>
+			</Rule>
+		</ProcessAccess>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 11 : FILE CREATED [FileCreate]-->
+		<!--DATA: RuleName, UtcTime, ProcessGuid, ProcessId, Image, TargetFilename, CreationUtcTime-->
+	<RuleGroup name="RG=FileCreate Include Group" groupRelation="or">
+		<FileCreate onmatch="include">
+			<!--MITRE ATT&CK TACTIC: Reconnaissance-->
+			<!--MITRE ATT&CK TECHNIQUE: Active Scanning-->
+			<TargetFilename name="Attack=T1595,Technique=Active Scanning,Tactic=Reconnaissance,Level=4,Alert=Nessus Temp Files Created,Risk=100" condition="contains">\TEMP\nessus_</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Host Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Identity Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Network Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Org Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Phishing for Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Closed Sources-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Open Technical Databases-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Open Websites/Domains-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Victim-Owned Websites-->
+
+			<!--MITRE ATT&CK TACTIC: Resource Development-->
+			<!--MITRE ATT&CK TECHNIQUE: Acquire Infrastructure-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Infrastructure-->
+			<!--MITRE ATT&CK TECHNIQUE: Develop Capabilities-->
+			<!--MITRE ATT&CK TECHNIQUE: Establish Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Obtain Capabilities-->
+			<!--MITRE ATT&CK TECHNIQUE: Stage Capabilities-->
+
+			<!--MITRE ATT&CK TACTIC: Initial Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Drive-by Compromise-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploit Public-Facing Application-->
+			<!--MITRE ATT&CK TECHNIQUE: External Remote Services-->
+			<!--MITRE ATT&CK TECHNIQUE: Hardware Additions-->
+			<!--MITRE ATT&CK TECHNIQUE: Phishing-->
+			<!--MITRE ATT&CK TECHNIQUE: Replication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Supply Chain Compromise-->
+			<Rule name="Attack=T1195,Technique=Supply Chain Compromise,Tactic=Initial Access,Level=4,Alert=Solarwinds sunburst suspicious file writes,Risk=100" groupRelation="and">
+				<Image condition="contains any">solarwinds.businesslayerhost</Image>
+				<TargetFilename condition="contains any">.exe;.dll;.ps1;.mz;.jpg;.png</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1195,Technique=Supply Chain Compromise,Tactic=Initial Access,Level=4,Alert=Solarwinds sunburst malware dll,Risk=100" groupRelation="and">
+				<TargetFilename condition="is">C:\WINDOWS\SysWOW64\netsetupsvc.dll</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1195,Technique=Supply Chain Compromise,Tactic=Initial Access,Level=4,Alert=Dark Halo Software location,Risk=100" groupRelation="and">
+				<TargetFilename condition="begin with">C:\Windows\SoftwareDistribution</TargetFilename>
+				<TargetFilename name="Defender AntiMalware Delta Patch" condition="excludes all">C:\Windows\SoftwareDistribution\Download\Install\AM_Delta_Patch_;.exe</TargetFilename>
+				<TargetFilename condition="end with">.exe</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1195,Technique=Supply Chain Compromise,Tactic=Initial Access,Level=0,Desc=MSBuild Source Files created" groupRelation="or">
+				<TargetFilename condition="end with">proj</TargetFilename>
+				<TargetFilename condition="end with">.targets</TargetFilename>
+				<TargetFilename condition="end with">.build</TargetFilename>
+				<TargetFilename condition="end with">.props</TargetFilename>
+				<TargetFilename condition="end with">.tasks</TargetFilename>
+				<TargetFilename condition="end with">.sln</TargetFilename>
+				<TargetFilename condition="end with">.cs</TargetFilename>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Trusted Relationship-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts -->
+			
+			<!--MITRE ATT&CK TACTIC: Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter-->
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Batch File scripting: Batch scripts" condition="end with">.bat</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Batch scripting: Legacy btm Extension" condition="end with">.btm</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Batch scripting: Legacy cmd Extension" condition="end with">.cmd</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Batch scripting: Legacy com Extension" condition="end with">.com</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=CMDLine File Created" condition="end with">.cmdline</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Batch File Created" condition="end with">.bas</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=BIN file created" condition="end with">.bin</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=WMI Shell artifacts" condition="begin with">C:\Windows\SysWOW64\Wbem</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=WMI Shell artifacts" condition="begin with">C:\Windows\System32\Wbem</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=WS Scripting" condition="end with">.ws</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=WSC Scripting" condition="end with">.wsc</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=WSF Scripting" condition="end with">.wsf</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=WSH Scripting" condition="end with">.wsh</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=PIF Scripting" condition="end with">.pif</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter: MSHTA-->
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=MSHTA Scripting" condition="end with">.hta</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter: Python-->
+			<TargetFilename name="Attack=T1059.006,Technique=Command and Scripting Interpreter: Python,Tactic=Execution,Level=0,Desc=IronPython,Risk=90" condition="contains">IronPython</TargetFilename>
+			<TargetFilename name="Attack=T1059.006,Technique=Command and Scripting Interpreter: Python,Tactic=Execution,Level=0,Desc=Python" condition="end with">.py</TargetFilename>
+			<TargetFilename name="Attack=T1059.006,Technique=Command and Scripting Interpreter: Python,Tactic=Execution,Level=0,Desc=Python" condition="end with">.pyc</TargetFilename>
+			<TargetFilename name="Attack=T1059.006,Technique=Command and Scripting Interpreter: Python,Tactic=Execution,Level=0,Desc=Python" condition="end with">.pyd</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter: Powershell-->
+			<Rule name="Attack=T1059.001,Technique=Command and Scripting Interpreter: PowerShell,Tactic=Execution,Level=2,Alert=Powershell file types,Risk=100" groupRelation="or">
+				<TargetFilename condition="end with">.cdxml</TargetFilename>
+				<TargetFilename condition="end with">.ps1</TargetFilename>
+				<TargetFilename condition="end with">.ps1xml</TargetFilename>
+				<TargetFilename condition="end with">.psc1</TargetFilename>
+				<TargetFilename condition="end with">.psd1</TargetFilename>
+				<TargetFilename condition="end with">.psm1</TargetFilename>
+				<TargetFilename condition="end with">.pssc</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1059.001,Technique=Command and Scripting Interpreter: PowerShell,Tactic=Execution,Level=2,Alert=Powershell file creations,Risk=10" groupRelation="and">
+				<Image condition="contains any">powershell.exe;powershell_ise.exe</Image>
+			</Rule>
+			<TargetFilename name="Attack=T1059.001,Technique=Command and Scripting Interpreter: PowerShell,Tactic=Execution,Level=0,Desc=Powershell directory modifications" condition="begin with">C:\Windows\SysWOW64\WindowsPowerShell</TargetFilename>
+			<TargetFilename name="Attack=T1059.001,Technique=Command and Scripting Interpreter: PowerShell,Tactic=Execution,Level=0,Desc=Powershell directory modifications" condition="begin with">C:\Windows\System32\WindowsPowerShell</TargetFilename>
+			<TargetFilename name="Attack=T1059.001,Technique=Command and Scripting Interpreter: PowerShell,Tactic=Execution,Level=0,Desc=Persistence: PowerShell default profile" condition="begin with">c:\Windows\System32\WindowsPowerShell\v1.0\profile</TargetFilename>
+			<TargetFilename name="Attack=T1059.001,Technique=Command and Scripting Interpreter: PowerShell,Tactic=Execution,Level=0,Desc=Persistence: PowerShell default profile" condition="begin with">c:\Windows\Syswow64\WindowsPowerShell\v1.0\profile</TargetFilename>
+			<TargetFilename name="Attack=T1059.001,Technique=Command and Scripting Interpreter: PowerShell,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\UsageLogs\powershell.exe.log</TargetFilename>
+			<TargetFilename name="Attack=T1059.001,Technique=Command and Scripting Interpreter: PowerShell,Tactic=Execution,Level=0,Desc=Powershell Console History" condition="end with">PSReadLine\ConsoleHost_history.txt</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter: Javascript-->
+			<TargetFilename name="Attack=T1059.007,Technique=Command and Scripting Interpreter: JavaScript,Tactic=Execution,Level=0,Desc=vbs script created" condition="end with">.vbs</TargetFilename>
+			<TargetFilename name="Attack=T1059.007,Technique=Command and Scripting Interpreter: JavaScript,Tactic=Execution,Level=0,Desc=Java JRE Timestamp usage for DFIR" condition="contains">.oracle_jre_usage\</TargetFilename>
+			<TargetFilename name="Attack=T1059.007,Technique=Command and Scripting Interpreter: JavaScript,Tactic=Execution,Level=0,Desc=JavaScript" condition="end with">.js</TargetFilename>
+			<TargetFilename name="Attack=T1059.007,Technique=Command and Scripting Interpreter: JavaScript,Tactic=Execution,Level=0,Desc=JavaScript" condition="end with">.jse</TargetFilename>
+			<TargetFilename name="Attack=T1059.005,Technique=Command and Scripting Interpreter: VisualBasic,Tactic=Execution,Level=0,Desc=VisualBasicScripting" condition="end with">.vb</TargetFilename>
+			<TargetFilename name="Attack=T1059.005,Technique=Command and Scripting Interpreter: VisualBasic,Tactic=Execution,Level=0,Desc=VisualBasicScripting" condition="end with">.vbe</TargetFilename>
+			<TargetFilename name="Attack=T1059.005,Technique=Command and Scripting Interpreter: VisualBasic,Tactic=Execution,Level=0,Desc=VisualBasicScripting" condition="end with">.vbsript</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Container Administration Command-->
+			<!--MITRE ATT&CK TECHNIQUE: Deploy Container-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Client Execution-->
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=0,Desc=CVE-2019-1315,Risk=70" groupRelation="and">
+				<TargetFilename condition="end with">Report.wer.tmp</TargetFilename>
+				<TargetFilename condition="excludes">\WER\</TargetFilename>
+				<Image condition="image">C:\Windows\system32\wermgr.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=0,Desc=Office App Creating Exe File,Risk=70" groupRelation="and">
+				<Image condition="contains any">winword.exe;excel.exe;powerpnt.exe;outlook.exe;msaccess.exe;mspub.exe;visio.exe;notepad.exe;wordpad.exe</Image>
+				<TargetFilename condition="end with">.exe</TargetFilename>
+				<TargetFilename condition="begin with">C:\Users</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=0,Desc=Office App Creating DLL File,Risk=70" groupRelation="and">
+				<Image condition="contains any">winword.exe;excel.exe;powerpnt.exe;outlook.exe;msaccess.exe;mspub.exe;visio.exe;notepad.exe;wordpad.exe</Image>
+				<TargetFilename condition="end with">.dll</TargetFilename>
+				<TargetFilename condition="begin with">C:\Users</TargetFilename>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Inter-Process Communication-->
+			<!--MITRE ATT&CK TECHNIQUE: Native API-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<!--MITRE ATT&CK TECHNIQUE: Shared Modules-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Deployment Tools-->
+			<!--MITRE ATT&CK TECHNIQUE: System Services-->
+			<!--MITRE ATT&CK TECHNIQUE: User Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: User Execution: Malicious File-->
+			<Rule name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Generic Ransomware Detection" groupRelation="and">
+				<TargetFilename condition="contains any">!!!-WARNING-!!!.html;!!!-WARNING-!!!.txt;!!! HOW TO DECRYPT FILES !!!;!!!README!!!;!!!READ_TO_UNLOCK!!!.TXT;!!!_READ_ME_;!Recovery_;!Where_are_my_files!.html;!_HOW_TO_RESTORE_;!_RECOVERY_HELP_!.txt;!recover!;# DECRYPT MY FILES #.html;# DECRYPT MY FILES #.txt;# DECRYPT MY FILES #.vbs;# SATAN CRYPTOR #;+recover+;.8lock8;.31392E30362E32303136_;.ABCDEF;.CIop;.CR1;.CRAB;.CRYPTOSHIELD;.Cl0p;.Contact_Here_To_Recover_Your_Files.txt;.CryptoTorLocker2015!;.HERMES;.HakunaMatata;.How_To_Decrypt.txt;.How_To_Get_Back.txt;.KEYZ.KEYH0LES;.L0CKED;.LOL!;.MATRIX;.OMG!;.R.i.P;.RMCM1;.RSplited;.SUPERCRYPT;.SecureCrypted;.TheTrumpLocker;.VBRANSOM;.VforVendetta;.Where_my_files.txt;.XBTL;._AiraCropEncrypted!;.airacropencrypted!;.areyoulovemyrans;.berkshire;.bitpy;.bitx;.blocatto;.bomber;.braincrypt;.breakingbad;.breeding123;.cerber;.cifgksaffsfyghd;.country82000;.crypt;.crypted;.crypton;.cryptotorlocker;.decrypt2017;.deria;.dglnl;.disposed2017;.doomed;.encrypted.locked;.encrypted;.encryptedyourfiles;.enjey;.evillock;.filegofprencrp;.fileiscryptedhard;.firecrypt;.fuckyourdata;.gangbang;.gefickt;.googl;.happydayzz;.hceem;.helpdecrypt;.helpmeencedfiles;.hnumkhotep;.hydracrypt_ID;.iaufkakfhsaraf;.info.txt;.jimm;.kharma;.killedXXX;.lambda_l0cked;.letmetrydecfiles;.locked;.locker16;.loveransisgood;.lovewindows;.magic_software_syndicate;.mention9823;.moments2900;.myrandsext2017;.newlock;.no_more_ransom;.nochance;.noproblemwedecfiles;.notfoundrans;.ohwqg;.one-we_can-help_you;.oops;.osiris;.otherinformation;.paytounlock;.powerfulldecrypt;.powned;.pr0lock;.prolock;.prosperous666;.pwnd;.ransom;.readme2unlock;.righ;.roger;.ryk;.satan;.savethequeen;.sigaint.org;.skjdthghh;.skynet;.snatch;.stubbin;.supported2017;.suppose666;.theworldisyours;.txd0t;.warn_wallet;.weapologize;.weareyourfriends;.weencedufiles;.wowreadfordecryp;.wowwhereismyfiles;.wvtr0;.yourransom;.zzzzz ;.{CRYPTENDBLACKDC};-DECRYPT.txt;000-IF-YOU-WANT-DEC-FILES;000-No-PROBLEM-WE-DEC-FILES;000-PLEASE-READ-WE-HELP;001-READ-FOR-DECRYPT-FILES;1025-7152.exe;:\windows\update_collector.exe;==READ==THIS==PLEASE==;@cock.li;@countermail.com;@firemail.cc;@india.com;@mail.ru;@ukr.net;ASSISTANCE_IN_RECOVERY;ATTENTION!!!.txt;ATTENTION.url;Aescrypt.exe;AllFilesAreLocked;BTC_DECRYPT_FILES;BUYUNLOCKCODE.txt;BUYUNLOCKCODE;BitCryptorFileList.txt;C:\ProgramData\dtb.dat;C:\Programdata\WinMgr;C:\Programdata\clean.bat;C:\Programdata\run.bat;C:\Windows\svchost.exe;CEBER3;CHECK-IT-HELP-FILES;COME_RIPRISTINARE_I_FILE.;COMO_ABRIR_ARQUIVOS.txt;COMO_RESTAURAR_ARCHIVOS;Coin.Locker.txt;Comment débloquer mes fichiers.txt;Como descriptografar seus arquivos.txt;Corona-virus-Map;Corona.bat;Corona.sfx;CryptoRansomware;Crytp0l0cker;Cyber SpLiTTer Vbs.exe;Cyborg_DECRYPT;DALE_FILES.TXT;DECRYPT-FILES;DECRYPTION INSTRUCTIONS.;DECRYPTION_HOWTO.Notepad;DECRYPT_INFORMATION;DECRYPT_INSTRUCTION.HTML;DECRYPT_INSTRUCTION.URL;DECRYPT_INSTRUCTIONS.html;DECRYPT_INSTRUCTIONS;DECRYPT_ReadMe1.TXT;DECRYPT_Readme.TXT.ReadMe;DECRYPT_YOUR_FILES;DESIFROVANI_POKYNY.html;Decrypt All Files;DecryptAllFiles;DecryptFile;Decrypt_readme.txt;DesktopOsiris;ENTSCHLUSSELN_HINWEISE.html;EdgeLocker;FILESAREGONE.txt;FILES_BACK.txt;File Decrypt Help.html;GJENOPPRETTING_AV_FILER;GetYouFiles.txt;HAPPEN-ENCED-FILES;HELLOTHERE.TXT;HELP-ME-ENCED-FILES;HELPDECRYPT_YOUR_FILES.HTML;HELP_DECRYPT.HTML;HELP_DECRYPT.PNG;HELP_DECRYPT.URL;HELP_DECRYPT.lnk;HELP_ME_PLEASE.txt;HELP_RESTORE_FILES_;HELP_TO_SAVE_FILES.bmp;HELP_TO_SAVE_FILES;HELP_YOURFILES.HTML;HELP_YOUR_FILES.PNG;HELP_YOUR_FILES.html;HELP_YOUR_FILES;HOW-TO-DECRYPT-FILES.HTML;HOW-TO-RESTORE-FILES;HOW TO BACK YOUR FILES;HOW TO DECRYPT FILES.HTML;HOW TO DECRYPT FILES.txt;HOW TO RECOVER;HOWTO_RECOVER_FILES_;HOWTO_RESTORE_FILES;HOWTO_RESTORE_FILES_;HOW_DECRYPT.HTML;HOW_DECRYPT.TXT;HOW_DECRYPT.URL;HOW_OPEN_FILES;HOW_TO_DECRYPT.HTML;HOW_TO_DECRYPT_;HOW_TO_PAY_THE_RANSOM;HOW_TO_RESTORE_FILES.html;HOW_TO_RESTORE_FILES;HOW_TO_RESTORE_YOUR_DATA;HOW_TO_UNLOCK_FILES_README_;HWID Lock.exe;Hacked_Read_me_to_decrypt_files.html;Help Decrypt.html;How decrypt files.hta;How to decrypt LeChiffre files.html;How to decrypt your data.txt;HowDecrypt.gif;HowDecrypt.txt;How_to_decrypt_your_files.jpg;How_to_restore_files.hta;HowtoRestore_File;HowtoRestore_Files;Howto_RESTORE_FILES.html;Howto_Restore_FILES.TXT;IAMREADYTOPAY.TXT;IF-YOU-WANT-DEC-FILES;IF_WANT_FILES_BACK_PLS_READ.html;IHAVEYOURSECRET.KEY;IMPORTANT READ ME.txt;IMPORTANT.README;INSTALL_TOR.URL;INSTRUCCIONES;INSTRUCCIONES_DESCIFRADO.html;INSTRUCTION RESTORE FILE;INSTRUCTIONS_DE_DECRYPTAGE.html;INSTUCCIONES_DESCRIFRADO;ISTRUZIONI_DECRITTAZIONE.html;Important!.txt;Instructionaga.txt;KryptoLocker_README.txt;LEER_INMEDIATAMENTE;LET-ME-TRY-DEC-FILES;Locked-by-Mafia;MENSAGEM.txt;MERRY_I_LOVE_YOU_BRUCE.hta;No-PROBLEM-WE-DEC-FILES;OKSOWATHAPPENDTOYOURFILES.TXT;ONTSLEUTELINGS_INSTRUCTIES.html;OSIRIS-;PAYLOADBIN;PINGY@INDIA.COM;PLEASE-READ-WE-HELP.;PLEASE-READIT-IF_YOU-WANT.html;PLEASE-READIT-IF_YOU-WANT;PLEASE-README-AFFECTED-FILES;PLS-DEC-MY-FILES;PURELOCKER;Payment_Instructions.jpg;Please Read Me!!!;READ-FOR-DECCCC-FILESSS;READ-FOR-DECRYPT-FILES;READ-READ-READ;READ IF YOU WANT YOUR FILES BACK.html;READ ME FOR DECRYPT.txt;README HOW TO DECRYPT YOUR FILES.HTML;README!!!;README_DECRYPT_HYDRA_ID_;README_DECRYPT_HYRDA_ID_;README_DECRYPT_UMBRE_ID_;README_DONT_DELETE;README_HOW_TO_UNLOCK.HTML;README_HOW_TO_UNLOCK.TXT;README_RECOVER_FILES_;README_TO_RECURE_YOUR_FILES;READTHISNOW!!!.txt;READ_IT.txt;READ_ME_!.txt;READ_ME_TO_DECRYPT_YOU_INFORMA;READ_THIS_TO_DECRYPT.html;RECOVER-FILES;RECOVERY_FILE.;RECOVERY_FILES.TXT;RECOVER_MY_FILE;RESTORE_CORUPTED_FILES;RESTORE_FILES_;RETURN FILES.txt;RETURN YOUR FILES;RETURNFILES_.txt;RETURN_FILES.txt;RETURN_FILES_.txt;Rans0m_N0te_Read_ME;Read Me (How Decrypt) !!!!.txt;ReadDecryptFilesHere;Read_this_file.txt;Receipt.exe;RecoveryManual.html;Recovery_File_;Recovery_file_;Rooster865qq;SECRET.KEY;SECRETIDHERE.KEY;SHTODELATVAM.txt;SIFRE_COZME_TALIMATI.html;SORRY-FOR-FILES;Survey Locker.exe;TRY-READ-ME-TO-DEC;Temp\satan\satan;ThxForYurTyme;UNLOCK_FILES_INSTRUCTIONS.html;UNLOCK_FILES_INSTRUCTIONS.txt;UnblockFiles.vbs;VIP72.exe;Vape Launcher.exe;WANT_FILES_BACK;WE-MUST-DEC-FILES;WHERE-YOUR-FILES;WORMKILLER@INDIA.COM.XTBL;What happen to my files.txt;Whereisyourfiles;WindowsApplication1.exe;YOUGOTHACKED.TXT;YOUR_FILES.txt;YOUR_FILES.url;YOUR_FILES_ARE_DEAD;YOUR_FILES_ARE_ENCRYPTED.HTML;YOUR_FILES_ARE_ENCRYPTED.TXT;YOUR_FILES_ARE_LOCKED.txt;Your files are locked !!!!.txt;Your files are locked !!!.txt;Your files are locked !!.txt;Your files are locked !.txt;Your files encrypted by our friends !!! txt;Your files encrypted by our friends !!!.txt;[KASISKI];_Adatok_visszaallitasahoz_utasitasok;_DECRYPT_ASSISTANCE_;_DECRYPT_INFO_;_DECRYPT_INFO_szesnl;_DEC_FILES.;_FILES_WERE_ENCRYPTED_@.TXT;_HELP_HELP_HELP_;_HELP_Recover_Files_;_HELP_instructions.bmp;_HELP_instructions.txt;_HOWDO_text.bmp;_HOWDO_text.html;_HOW_TO_Decrypt;_H_e_l_p_RECOVER_INSTRUCTIONS+;_H_e_l_p_RECOVER_INSTRUCTIONS;_Locky_recover;_Locky_recover_instructions.bmp;_Locky_recover_instructions.txt;_README.hta;_README.jpg;_READ_ME!;_RECOVER_INSTRUCTIONS;_ReCoVeRy_+;_USE_TO_FIX_;_WHAT_is.html;_help_instruct;_how_recover.txt;_how_recover;_how_recover_;_recover_;_secret_code.txt;_steaveiwalker@india.com_;aeroware;confirmation.key;contains(to_string($message.file_created), "howrecover+;crjoker.html;cryptinfo.txt;cryptolocker.;cryptopp;de_crypt_readme.;de_crypt_readme.bmp;de_crypt_readme.html;de_crypt_readme.txt;decipher_ne;decrypt-instruct;decrypt explanations.;decrypt my file;decrypt your file;decrypt_Globe;decrypt_instruct;decrypted_files.dat;decryptional;decryptmyfiles;decypt_your_files.html;default32643264.bmp;default432643264.jpg;email-salazar_slytherin10;enc_files.txt;encryptor_raas_readme_liesmich;enigma.hta;enigma_encr.txt;exit.hhr.obleep;fattura_;file0locked;files_are_encrypted.;-filesencrypted;firemail.cc;firstransomware.exe;gmx.de;hacks.at.sigaint.org;help-file-decrypt.enc;help_decrypt;help_file_;help_instructions.;help_my_files;help_recover;help_recover_instructions;help_restore;help_restore_files;help_your_file;helpmeencedfiles;how to decrypt aes files.lnk;how to decrypt;how to get data.txt;how_decrypt.gif;how_recover;how_to_decrypt;how_to_recover;howrecover+ recoveryfile_;howrecover+;howto_recover_file;howto_restore;howtodecrypt;howtodecryptaesfiles.txt;inbox.ru;info@kraken.cc_worldcza@email.cz;install_tor;iran.ir;last_chance.txt;maestro@pizzacrypts.info;maxcrypt.bmp;only-we_can-help_you;openforyou@india.com;opensourcemail.org;padcrypt;paycrypt.bmp;popcorn_time.exe;powerfulldecrypt;protonmail.ch;qbmail.biz;randomname;readme_decrypt;readme_for_decrypt;readme_liesmich_encryptor_raas;recover_file;recover_file_;recover_instruction;recoverfile;recoverfile_;recovery+;recovery_file.txt;recovery_key.txt;recoveryfile;recover}-;restore_files.txt;restorefiles;restorefiles_;ryukreadme.html;tuta.io;tutanota.com;tutanota.de;unCrypte;vault.hta;vault.key;vault.txt;want your files back.;warning-!!;wie_zum_Wiederherstellen_von_Dateien.txt;wowreadfordecryp;wowwhereismyfiles;zXz.html;zycrypt.;zzzzzzzzzzzzzzzzzyyy</TargetFilename>
+			</Rule>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Common Files of CrackMapExec,Risk=100" condition="contains">crackmapexec</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Common Files of CrackMapExec,Risk=100" condition="end with">\Crypto.Cipher._AES.pyd</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Common Files of CrackMapExec,Risk=100" condition="end with">\Crypto.Cipher._DES.pyd</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Common Files of CrackMapExec,Risk=100" condition="end with">\Crypto.Hash._SHA256.pyd</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Common Files of CrackMapExec,Risk=100" condition="end with">\Crypto.Random.OSRNG.winrandom.pyd</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Common Files of CrackMapExec,Risk=100" condition="end with">\Crypto.Util.strxor.pyd</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Common Files of CrackMapExec,Risk=100" condition="end with">\crackmapexec.exe.manifest</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Common Files of CrackMapExec,Risk=100" condition="end with">\greenlet.pyd</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=KeeFarce.exe default injected DLL name,Risk=100" condition="end with">BootStrapDLL.dll</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=MegaCortex Ransomware,Risk=100" condition="begin with">C:\windows\temp\wininit.exe</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=Mimikatz Files" condition="contains any">lazycat;powerkatz;mimikatz;mimidrv;mimilove;mimilib;mimikittenz;mimiauth;invoke-mimi</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=RDP Wrapper,Risk=100" condition="end with">rdpwrap.dll</TargetFilename>
+			<TargetFilename name="Attack=T1204.002,Technique=Malicious File,Tactic=Execution,Level=4,Alert=winspool.drv dropped" condition="end with">winspool.drv</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Windows Management Instrumentation-->
+			<TargetFilename name="Attack=T1047,Technique=Windows Management Instrumentation,Tactic=Execution" condition="begin with">C:\Windows\System32\Wbem</TargetFilename>
+			<TargetFilename name="Attack=T1047,Technique=Windows Management Instrumentation,Tactic=Execution" condition="begin with">C:\Windows\SysWOW64\Wbem</TargetFilename>
+			<Image name="Attack=T1047,Technique=Windows Management Instrumentation,Tactic=Execution" condition="begin with">C:\WINDOWS\system32\wbem\scrcons.exe</Image>
+			<!--MITRE ATT&CK TACTIC: Persistence-->
+			<!--MITRE ATT&CK TECHNIQUE: Account Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: BITS Jobs-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Autostart Execution-->
+			<TargetFilename name="Attack=T1547.001,Technique=Registry Startup Folder,Tactic=Persistence,Level=3,Alert=Autorun Folder Entries" condition="contains">\Programs\Startup\</TargetFilename>
+			<TargetFilename name="Attack=T1547.001,Technique=Registry Startup Folder,Tactic=Persistence,Level=3,Alert=Autorun Folder Entries" condition="contains">\Startup\</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Initialization Scripts-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Extensions-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Client Software Binary-->
+			<!--MITRE ATT&CK TECHNIQUE: Create Account-->
+			<!--MITRE ATT&CK TECHNIQUE: Create or Modify System Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Event Triggered Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: External Remote Services-->
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<!--MITRE ATT&CK TECHNIQUE: Implant Internal Image-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Office Application Startup-->
+			<TargetFilename name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence,Level=0,Desc=Office Application Startup modification" condition="contains">\Word\STARTUP\</TargetFilename>
+			<TargetFilename name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence,Level=0,Desc=Office Application Startup modification" condition="contains">\Microsoft\Templates\</TargetFilename>
+			<TargetFilename name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence,Level=0,Desc=Office Application Startup modification" condition="contains">\Excel\XLSTART\</TargetFilename>
+			<TargetFilename name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence" condition="end with">.dotm</TargetFilename>
+			<TargetFilename name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence" condition="end with">.XLSB</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Pre-OS Boot-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\Tasks\</TargetFilename> <!--Microsoft:ScheduledTasks -->
+			<!--MITRE ATT&CK TECHNIQUE: Server Software Component-->
+			<Rule name="Attack=T1505.003,Technique=Server Software Component: Web Shell,Tactic=Persistence,Level=3,Alert=HAFNIUM APT: IIS Creating ASPX files outside of wwwwroot,Risk=80" groupRelation="and">
+				<Image condition="image">w3wp.exe</Image>
+				<TargetFilename condition="end with">.aspx</TargetFilename>
+				<TargetFilename condition="excludes">\wwwroot\aspnet_client\</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1505.003,Technique=Server Software Component: Web Shell,Tactic=Persistence,Level=0,Desc=HAFNIUM APT: IIS Creating PHP files,Risk=80" groupRelation="and">
+				<Image condition="image">w3wp.exe</Image>
+				<TargetFilename condition="end with">.php</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1505.003,Technique=Server Software Component: Web Shell,Tactic=Persistence,Level=0,Desc=HAFNIUM APT: IIS Creating AAA files,Risk=80" groupRelation="and">
+				<Image condition="image">w3wp.exe</Image>
+				<TargetFilename condition="end with">.aaa</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1505.003,Technique=Server Software Component: Web Shell,Tactic=Persistence,Level=3,Alert=HAFNIUM Web Shells Dropped,Risk=100" groupRelation="and">
+				<TargetFilename condition="contains any">\wwwroot\aspnet_client\</TargetFilename>
+				<TargetFilename condition="contains any">.aspx;.php</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1505.003,Technique=Server Software Component: Web Shell,Tactic=Persistence,Level=0,Desc=Files dropped in wwwroot directory,Risk=40" groupRelation="and">
+				<TargetFilename condition="contains any">\wwwroot\</TargetFilename>
+				<TargetFilename condition="excludes any">\wwwroot\aspnet_client\;jpg</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1505.003,Technique=Server Software Component: Web Shell,Tactic=Persistence,Level=0,Desc=ASP Files dropped outside wwwroot directory" groupRelation="and">
+				<TargetFilename condition="end with">.asp</TargetFilename>
+				<TargetFilename condition="excludes any">\wwwroot\</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1505.003,Technique=Server Software Component: Web Shell,Tactic=Persistence,Level=0,Desc=ASPX Files dropped outside wwwroot directory" groupRelation="and">
+				<TargetFilename condition="end with">.aspx</TargetFilename>
+				<TargetFilename condition="excludes any">\wwwroot\</TargetFilename>
+			</Rule>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ecp\auth\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\oab\auth\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">ClientAccess\Owa\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\owa\auth\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">httpproxy\rpc\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">ClientAccess\ecp\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\htdocs\</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+
+			<!--MITRE ATT&CK TACTIC: Privilege Escalation-->
+			<!--MITRE ATT&CK TECHNIQUE: Abuse Elevation Control Mechanism-->
+			<!--MITRE ATT&CK TECHNIQUE: Access Token Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Autostart Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Initialization Scripts-->
+			<!--MITRE ATT&CK TECHNIQUE: Create or Modify System Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Policy Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Escape to Host-->
+			<!--MITRE ATT&CK TECHNIQUE: Event Triggered Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Privilege Escalation-->
+			<Rule name="Attack=T1068,Technique=Exploitation for Privilege Escalation,Tactic=Privilege Escalation,Level=0,Desc=Printer Exploitation Detected,Risk=20" groupRelation="and">
+				<TargetFilename condition="end with">.SPL</TargetFilename>
+				<Image condition="excludes any">spoolsv.exe;printfilterpipelinesvc.exe;printisolationhost.exe;splwow64.exe;msiexec.exe;poqexec.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1068,Technique=Exploitation for Privilege Escalation,Tactic=Privilege Escalation,Level=0,Desc=Printer Spooler Created exe file,Risk=40" groupRelation="and">
+				<Image condition="image">spoolsv.exe</Image>
+				<TargetFilename condition="end with">.exe</TargetFilename>
+				<TargetFilename condition="excludes">C\:\Windows\System32\spool\;C\:\Windows\Temp\;C\:\Users\</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1068,Technique=Exploitation for Privilege Escalation,Tactic=Privilege Escalation,Level=0,Desc=InstallerFileTakeOver,Risk=80,CVE=CVE-2021-41379" groupRelation="and">
+				<Image condition="image">msiexec.exe</Image>
+				<TargetFilename condition="contains">\Microsoft\Edge\Application</TargetFilename>
+				<TargetFilename condition="end with">elevation_service.exe</TargetFilename>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Injection-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+
+			<!--MITRE ATT&CK TACTIC: Defense Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Abuse Elevation Control Mechanism-->
+			<!--MITRE ATT&CK TECHNIQUE: Access Token Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: BITS Jobs-->
+			<!--MITRE ATT&CK TECHNIQUE: Build Image on Host-->
+			<!--MITRE ATT&CK TECHNIQUE: Debugger Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Deobfuscate/Decode Files or Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Deploy Container-->
+			<!--MITRE ATT&CK TECHNIQUE: Direct Volume Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Policy Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Execution Guardrails-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Defense Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: File and Directory Permissions Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Hide Artifacts-->
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<!--MITRE ATT&CK TECHNIQUE: Impair Defenses-->
+			<!--MITRE ATT&CK TECHNIQUE: Indicator Removal on Host-->
+			<!--MITRE ATT&CK TECHNIQUE: Indirect Command Execution-->
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\LocalState\rootfs\</TargetFilename>
+
+			<!--MITRE ATT&CK TECHNIQUE: Masquerading-->
+			<Rule name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Risk=20,Level=0,Desc=Monitor Common Masquarading Locations" groupRelation="or">
+				<TargetFilename condition="begin with">C:\PerfLogs\</TargetFilename> 
+				<TargetFilename condition="begin with">C:\Temp\</TargetFilename> 
+				<TargetFilename condition="begin with">C:\Users\Default\</TargetFilename> 
+				<TargetFilename condition="begin with">C:\Users\Public\</TargetFilename> 
+				<TargetFilename condition="begin with">C:\Windows\Temp\</TargetFilename> 
+				<TargetFilename condition="contains">\AppData\Temp\</TargetFilename>
+				<Image condition="excludes">C:\WINDOWS\system32\dxgiadaptercache.exe</Image>
+			</Rule>
+			<TargetFilename condition="contains" name="Level=0,Desc=Recycle bin files created">$Recycle.Bin</TargetFilename>
+			<Image condition="contains" name="Level=0,Desc=Files Created from">$Recycle.Bin</Image>
+			<Rule name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Risk=20,Level=0,Desc=Files Created within System Profile" groupRelation="and">
+				<TargetFilename condition="begin with">C:\Windows\</TargetFilename>
+				<TargetFilename condition="contains">\config\systemprofile\</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1036,Technique=Masquerading,Tactic=Defense Evasion,Risk=20,Level=0,Desc=Files Created from System Profile executable" groupRelation="and">
+				<Image condition="begin with">C:\Windows\</Image>
+				<Image condition="contains">\config\systemprofile\</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Cloud Compute Infrastructure-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Registry-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify System Image-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Boundary Bridging-->
+			<!--MITRE ATT&CK TECHNIQUE: Obfuscated Files or Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Plist File Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Pre-OS Boot-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Injection-->
+			<!--MITRE ATT&CK TECHNIQUE: Reflective Code Loading-->
+			<!--MITRE ATT&CK TECHNIQUE: Rogue Domain Controller-->
+			<!--MITRE ATT&CK TECHNIQUE: Rootkit-->
+			<!--MITRE ATT&CK TECHNIQUE: Subvert Trust Controls-->
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Compiled HTML File-->
+			<TargetFilename name="Attack=T1223,Technique=Compiled HTML File,Tactic=Defense Evasion" condition="end with">.chm</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Regsvr32-->
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: MsiExec-->
+			<!--MITRE ATT&CK TECHNIQUE: System Script Proxy Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Template Injection-->
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Trusted Developer Utilities Proxy Execution-->
+			<TargetFilename name="Attack=T1127,Technique=Trusted Developer Utilities Proxy Execution,Tactic=Defense Evasion" condition="end with">proj</TargetFilename>
+			<TargetFilename name="Attack=T1127,Technique=Trusted Developer Utilities Proxy Execution,Tactic=Defense Evasion" condition="end with">.sln</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Unused/Unsupported Cloud Regions-->
+			<!--MITRE ATT&CK TECHNIQUE: Use Alternate Authentication Material-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Virtualization/Sandbox Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Weaken Encryption-->
+			<!--MITRE ATT&CK TECHNIQUE: XSL Script Processing-->
+
+			<!--MITRE ATT&CK TACTIC: Credential Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Adversary-in-the-Middle-->
+			<!--MITRE ATT&CK TECHNIQUE: Brute Force-->
+			<!--MITRE ATT&CK TECHNIQUE: Credentials from Password Stores-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Credential Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Forced Authentication-->
+			<!--MITRE ATT&CK TECHNIQUE: Forge Web Credentials-->
+			<!--MITRE ATT&CK TECHNIQUE: Input Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Factor Authentication Interception-->
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Factor Authentication Request Generation-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Sniffing-->
+			<!--MITRE ATT&CK TECHNIQUE: OS Credential Dumping-->
+			<!--MITRE ATT&CK TECHNIQUE: Steal Application Access Token-->
+			<!--MITRE ATT&CK TECHNIQUE: Steal or Forge Kerberos Tickets-->
+			<!--MITRE ATT&CK TECHNIQUE: Steal Web Session Cookie-->
+			<!--MITRE ATT&CK TECHNIQUE: Unsecured Credentials-->
+
+			<!--MITRE ATT&CK TACTIC: Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Account Discovery -->
+			<!--MITRE ATT&CK TECHNIQUE: Application Window Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Bookmark Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Infrastructure Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Service Dashboard-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Storage Object Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Container and Resource Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Debugger Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Trust Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: File and Directory Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Group Policy Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Share Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Sniffing-->
+			<!--MITRE ATT&CK TECHNIQUE: Password Policy Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Peripheral Device Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Permission Groups Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Query Registry-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote System Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Information Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Location Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Network Configuration Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Network Connections Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Owner/User Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Time Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Virtualization/Sandbox Evasion-->
+
+			<!--MITRE ATT&CK TACTIC: Lateral Movement-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation of Remote Services-->
+			<Rule name="Attack=T1203,Technique=Exploitation of Remote Services,Tactic=Lateral Movement,Level=4,Alert=Exchange Exploitation UM Service File Creation,Risk=80,CVE=CVE-2021-26858" groupRelation="and">
+				<Image condition="contains any">UMWorkerProcess.exe;UMService.exe</Image>
+				<TargetFilename condition="contains any">.</TargetFilename>
+				<TargetFilename condition="excludes any">.log;.cfg;.txt;cleanup;.HealthCheck;\wp.active;.db</TargetFilename>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Internal Spearphishing-->
+			<!--MITRE ATT&CK TECHNIQUE: Lateral Tool Transfer-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote Service Session Hijacking-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote Services-->
+			<!--MITRE ATT&CK TECHNIQUE: Replication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Deployment Tools-->
+			<!--MITRE ATT&CK TECHNIQUE: Taint Shared Content-->
+			<!--MITRE ATT&CK TECHNIQUE: Use Alternate Authentication Material-->
+
+			<!--MITRE ATT&CK TACTIC: Collection-->
+			<!--MITRE ATT&CK TECHNIQUE: Adversary-in-the-Middle-->
+			<!--MITRE ATT&CK TECHNIQUE: Archive Collected Data-->
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=7zip Archive" condition="end with">.7z</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=7zip Archive" condition="end with">.7zip</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=7zip Archive" condition="end with">.arj</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=7zip Archive" condition="end with">.s7z</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=.A Archive" condition="end with">.a</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=ACE Archive" condition="end with">.ace</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=AR Archive" condition="end with">.ar</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=ARC Archive" condition="end with">.arc</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=BIN" condition="end with">.bin</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=CAB Archive" condition="end with">.cab</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=Game PAK Archive" condition="end with">.pak</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=Gzip Archive" condition="end with">.gz</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=IMG Archive" condition="end with">.img</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=ISO Archive" condition="end with">.iso</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=LZM Archive" condition="end with">.lzm</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=LZMA Archive" condition="end with">.lzma</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Temp\Rar$</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=RAR Archive" condition="end with">.rar</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">RarSFX</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=SFX Archive" condition="end with">.sfx</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=SZ Archive" condition="end with">.sz</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=TAR Archive" condition="end with">.tar</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=TAR.GZ Archive" condition="end with">.tar.gz</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=XZ Archive" condition="end with">.xz</TargetFilename>
+			<TargetFilename name="Attack=T1560,Technique=Archive Collected Data,Tactic=Collection,Level=0,Desc=ZIP Archive" condition="end with">.zip</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Audio Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Automated Collection-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Session Hijacking-->
+			<!--MITRE ATT&CK TECHNIQUE: Clipboard Data-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Cloud Storage Object-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Configuration Repository-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Information Repositories-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Local System-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Network Shared Drive-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Staged-->
+			<!--MITRE ATT&CK TECHNIQUE: Email Collection-->
+			<TargetFilename name="Attack=T1114,Technique=Email Collection,Tactic=Collection,Level=0,Desc=Possible Email Collection/Exfiltration: .OST Created,Risk=30" condition="end with">.ost</TargetFilename>
+			<TargetFilename name="Attack=T1114,Technique=Email Collection,Tactic=Collection,Level=0,Desc=Possible Email Collection/Exfiltration: .PST Created,Risk=30" condition="end with">.eml</TargetFilename>
+			<TargetFilename name="Attack=T1114,Technique=Email Collection,Tactic=Collection,Level=0,Desc=Possible Email Collection/Exfiltration: .PST Created,Risk=30" condition="end with">.msg</TargetFilename>
+			<TargetFilename name="Attack=T1114,Technique=Email Collection,Tactic=Collection,Level=0,Desc=Possible Email Collection/Exfiltration: .PST Created,Risk=30" condition="end with">.pst</TargetFilename>
+			<!--MITRE ATT&CK TECHNIQUE: Input Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Screen Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Video Capture-->
+
+			<!--MITRE ATT&CK TACTIC: Command and Control-->
+			<!--MITRE ATT&CK TECHNIQUE: Application Layer Protocol-->
+			<!--MITRE ATT&CK TECHNIQUE: Communication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Encoding-->
+			<Rule name="Attack=T1132,Technique=Data Encoding,Tactic=Command and Control,Level=4,Alert=Cyrillic Letter obfuscation,Risk=100" groupRelation="and">
+				<TargetFilename condition="contains any">Г;И;К;П;д;и;к;л;л;н;н;о;ф;ե;թ;յ;ն;ն;ն;ն;տ;ւ;ք</TargetFilename>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Data Obfuscation-->
+			<!--MITRE ATT&CK TECHNIQUE: Dynamic Resolution-->
+			<!--MITRE ATT&CK TECHNIQUE: Encrypted Channel-->
+			<!--MITRE ATT&CK TECHNIQUE: Fallback Channels-->
+			<!--MITRE ATT&CK TECHNIQUE: Ingress Tool Transfer-->
+			<Image name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=File Created by Teamviewer" condition="is">Teamviewer.exe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">rundll32.exe</Image>
+			<Image name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=File Created with Remote Desktop Client" condition="is">mstsc.exe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">cmd.exe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">ipy.exe</Image>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">WScript.exe</Image>
+			<Image name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=File Dropped with cscript.exe,Risk=30" condition="is">cscript.exe</Image>
+			<Image name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=File Dropped with mshta.exe,Risk=100" condition="is">mshta.exe</Image>
+			<Image name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=File Dropped with python.exe,Risk=30" condition="is">python.exe</Image>
+			<Image name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=0,Desc=File Dropped with wmic.exe,Risk=30" condition="is">wmic.exe</Image>
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Stage Channels-->
+			<!--MITRE ATT&CK TECHNIQUE: Non-Application Layer Protocol-->
+			<!--MITRE ATT&CK TECHNIQUE: Non-Standard Port-->
+			<!--MITRE ATT&CK TECHNIQUE: Protocol Tunneling-->
+			<!--MITRE ATT&CK TECHNIQUE: Proxy-->
+			<!--MITRE ATT&CK TECHNIQUE: Proxy: Multi-hop Proxy-->
+			<TargetFilename name="Attack=T1090.003,Tactic=Command and Control,Technique=Multi-hop Proxy,Level=4,Alert=Potential Tor Hidden Service,Risk=100" condition="contains">HiddenService</TargetFilename>
+			<TargetFilename name="Attack=T1090.003,Tactic=Command and Control,Technique=Multi-hop Proxy,Level=4,Alert=Potential Tor Files,Risk=100" condition="end with">torrc</TargetFilename> 
+			<TargetFilename name="Attack=T1090.003,Tactic=Command and Control,Technique=Multi-hop Proxy,Level=4,Alert=Potential Tor Files,Risk=100" condition="contains">\tor.exe</TargetFilename> 
+			<TargetFilename name="Attack=T1090.003,Tactic=Command and Control,Technique=Multi-hop Proxy,Level=4,Alert=Potential Tor Files,Risk=100" condition="contains">tor-gencert</TargetFilename> 
+			<!--MITRE ATT&CK TECHNIQUE: Remote Access Software-->
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Web Service-->
+
+			<!--MITRE ATT&CK TACTIC: Exfiltration-->
+
+			<!--MITRE ATT&CK TECHNIQUE: Automated Exfiltration-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Transfer Size Limits-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Alternative Protocol-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over C2 Channel-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Other Network Medium-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Physical Medium-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Web Service-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Transfer-->
+			<!--MITRE ATT&CK TECHNIQUE: Transfer Data to Cloud Account-->
+			<TargetFilename name="Attack=T1114,Technique=Email Collection,Tactic=Collection,Level=4,Alert=Possible rclone Exfiltration,Risk=30" condition="contains">rclone</TargetFilename>
+			<TargetFilename name="Attack=T1114,Technique=Email Collection,Tactic=Collection,Level=4,Alert=Possible s3browser Exfiltration,Risk=30" condition="contains">s3browser</TargetFilename>
+			<TargetFilename name="Attack=T1114,Technique=Email Collection,Tactic=Collection,Level=4,Alert=Browser Credential exfiltration,Risk=30" condition="contains">grabff.exe</TargetFilename>
+			<TargetFilename name="Attack=T1114,Technique=Email Collection,Tactic=Collection,Level=4,Alert=Browser Credential exfiltration,Risk=30" condition="contains">grabff.exe</TargetFilename>
+			<!--MITRE ATT&CK TACTIC: Impact-->
+			<!--MITRE ATT&CK TECHNIQUE: Account Access Removal-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Destruction-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Encrypted for Impact-->
+			<Rule name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=Snatch Ransomware Detected,Risk=100" groupRelation="and">
+				<TargetFilename condition="contains all">RESTORE_;_FILES.txt</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=Snatch2 Ransomware Detected,Risk=100" groupRelation="and">
+				<TargetFilename condition="contains all">DECRYPT_;_FILES.txt</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=Nanocore Detected,Risk=100" groupRelation="and">
+				<TargetFilename condition="contains any">\run.dat;\task.dat;\storage.dat</TargetFilename>
+				<TargetFilename condition="contains">AppData</TargetFilename>
+				<TargetFilename condition="excludes any">Symantec</TargetFilename>
+				<TargetFilename condition="excludes any">BlueJeans</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=RagnarLocker Virtualbox files: susceptible to FP,Risk=40" groupRelation="and">
+				<TargetFilename condition="contains any">VBoxRT.dll;VboxC.dll</TargetFilename>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Data Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: Defacement-->
+			<!--MITRE ATT&CK TECHNIQUE: Disk Wipe-->
+			<!--MITRE ATT&CK TECHNIQUE: Endpoint Denial of Service-->
+			<!--MITRE ATT&CK TECHNIQUE: Firmware Corruption-->
+			<!--MITRE ATT&CK TECHNIQUE: Inhibit System Recovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Denial of Service-->
+			<!--MITRE ATT&CK TECHNIQUE: Resource Hijacking-->
+			<!--MITRE ATT&CK TECHNIQUE: Service Stop-->
+			<!--MITRE ATT&CK TECHNIQUE: System Shutdown/Reboot-->
+			<!--UEBA Detections-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="contains any">Content.IE5;INetCache</TargetFilename>
+				<TargetFilename condition="contains any">.exe;.zip;.ps1;.bat;.rar;.dll</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="contains any">MSForms.exd</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">.exe</TargetFilename> 
+				<TargetFilename condition="begin with">C:\windows\system32\</TargetFilename> 
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">.exe</TargetFilename> 
+				<TargetFilename condition="begin with">C:\windows\</TargetFilename> 
+				<TargetFilename condition="excludes">\system32\</TargetFilename> 
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="contains any">.dll;.exe</TargetFilename> 
+				<TargetFilename condition="excludes">C:\windows\</TargetFilename> 
+				<TargetFilename condition="excludes">C:\Users\</TargetFilename> 
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="contains any">.dll;.exe</TargetFilename> 
+				<TargetFilename condition="begin with">C:\Users\</TargetFilename> 
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="contains">\Microsoft\Word\Startup\</TargetFilename>
+				<TargetFilename condition="end with">.wll</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="begin with">C:\windows\system32\CodeIntegrity\</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="contains">\Microsoft\Excel\Startup\</TargetFilename>
+				<TargetFilename condition="end with">.xll</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">\Microsoft\Outlook\VbaProject.OTM</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="contains">\Microsoft\Addins\</TargetFilename>
+				<TargetFilename condition="contains any">.xla</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">.vsto</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">.bat</TargetFilename>
+				<TargetFilename condition="begin with">C:\Windows\</TargetFilename>
+				<Image condition="excludes any">C:\ProgramData\Lenovo\SystemUpdate\sessionSE\</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">.dll</TargetFilename>
+				<TargetFilename condition="begin with">C:\Windows\</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">.sys</TargetFilename>
+				<TargetFilename condition="begin with">C:\Windows\</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">.exe</TargetFilename>
+				<TargetFilename condition="begin with">C:\Windows\</TargetFilename>
+				<TargetFilename condition="excludes any">C:\Windows\System32\;C:\windows\syswow64\</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">.exe</TargetFilename>
+				<TargetFilename condition="begin with">C:\Windows\System32\</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">.exe</TargetFilename>
+				<TargetFilename condition="begin with">C:\Windows\SysWow64\</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">.theme</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="contains">\Packages\oice_</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="image">VirtualboxVM.exe</Image>
+			</Rule>
+			<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">notepad++.exe</Image>
+			<TargetFilename name="Attack=T1023,Technique=Shortcut Modification,Tactic=Persistence,Level=4,Alert=Potential LNK Malware File Downloaded">.lnk:Zone.Identifier</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\UsageLogs\cscript.exe.log</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\UsageLogs\mshta.exe.log</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\UsageLogs\msiexec.exe.log</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\UsageLogs\regsvr32.exe.log</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\UsageLogs\rundll32.exe.log</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\UsageLogs\svchost.exe.log</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\UsageLogs\wmic.exe.log</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\UsageLogs\wscript.exe.log</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Host Process" condition="end with">\regsvr32.exe.log</TargetFilename>
+			<TargetFilename name="Attack=T1059,Technique=Command and Scripting Interpreter,Tactic=Execution,Level=0,Desc=Execution: Susp ManagedCode Winrm Host Process" condition="end with">\UsageLogs\wsmprovhost.exe.log</TargetFilename>
+			<TargetFilename name="Level=0,Desc=Link">.lnk</TargetFilename>
+			<TargetFilename name="Level=0,Desc=URL">.url</TargetFilename>
+			<!--Drivers dropped-->
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.sys</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.inf</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\SysWOW64\Drivers</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\System32\Drivers</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Drivers\</TargetFilename>
+			<TargetFilename condition="end with">.drv</TargetFilename> 
+			<!--Microsoft Office File Monitoring-->
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xlam</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xlsm</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xla</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xll</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xls</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xlsb</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xlsx</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xlt</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xltm</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xlw</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Microsoft\Templates\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.eml</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.msg</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.pptm</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.potm</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.pptm</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.pptm</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.sldm</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Microsoft\Office\Recent</TargetFilename>
+			<TargetFilename name="Forensic=Recent Office History" condition="contains">oleObject</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Downloads\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Content.Outlook\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.docb</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.wbk</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.ped</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.dot</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.dotx</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.doc</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.docm</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.docx</TargetFilename>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="or">
+				<TargetFilename condition="end with">.accdb</TargetFilename>
+				<TargetFilename condition="end with">.accde</TargetFilename>
+				<TargetFilename condition="end with">.accdr</TargetFilename>
+				<TargetFilename condition="end with">.accdt</TargetFilename>
+				<TargetFilename condition="end with">.mdb</TargetFilename>
+				<TargetFilename condition="end with">.mde</TargetFilename>
+				<TargetFilename condition="end with">.msc</TargetFilename>
+				<TargetFilename condition="end with">.mst</TargetFilename>
+				<TargetFilename condition="end with">.potx</TargetFilename>
+				<TargetFilename condition="end with">.ppam</TargetFilename>
+				<TargetFilename condition="end with">.ppsm</TargetFilename>
+				<TargetFilename condition="end with">.ppsx</TargetFilename>
+				<TargetFilename condition="end with">.ppt</TargetFilename>
+				<TargetFilename condition="end with">.pptm</TargetFilename>
+				<TargetFilename condition="end with">.pptx</TargetFilename>
+				<TargetFilename condition="end with">.pub</TargetFilename>
+				<TargetFilename condition="end with">.sldm</TargetFilename>
+				<TargetFilename condition="end with">.sldx</TargetFilename>
+				<TargetFilename condition="end with">.xls</TargetFilename>
+				<TargetFilename condition="end with">.xps</TargetFilename>
+			</Rule>
+			<!--SECTION: Certificates -->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="or">
+				<TargetFilename condition="end with">.pem</TargetFilename>
+				<TargetFilename condition="end with">.crt</TargetFilename>
+				<TargetFilename condition="end with">.ca-bundle</TargetFilename>
+				<TargetFilename condition="end with">.cer</TargetFilename>
+				<TargetFilename condition="end with">.csr</TargetFilename>
+				<TargetFilename condition="end with">.der</TargetFilename>
+				<TargetFilename condition="end with">.p7b</TargetFilename>
+				<TargetFilename condition="end with">.p7r</TargetFilename>
+				<TargetFilename condition="end with">.p7s</TargetFilename>
+				<TargetFilename condition="end with">.pfx</TargetFilename>
+				<TargetFilename condition="end with">.sto</TargetFilename>
+				<TargetFilename condition="end with">.p12</TargetFilename>
+				<TargetFilename condition="end with">.crl</TargetFilename>
+				<TargetFilename condition="end with">.sst</TargetFilename>
+				<TargetFilename condition="end with">.key</TargetFilename>
+			</Rule>
+			<!-- side loading -->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="or">
+				<TargetFilename condition="end with">.hlp</TargetFilename>
+				<TargetFilename condition="end with">ACLUI.DLL.UI</TargetFilename>
+				<TargetFilename condition="end with">ACLUI.DLL</TargetFilename>
+				<TargetFilename condition="end with">AFLogVw.exe</TargetFilename>
+				<TargetFilename condition="end with">AShld.exe</TargetFilename>
+				<TargetFilename condition="end with">AShldRes.DLL.asr</TargetFilename>
+				<TargetFilename condition="end with">AShldRes.DLL</TargetFilename>
+				<TargetFilename condition="end with">AhnI2.dll</TargetFilename>
+				<TargetFilename condition="end with">CamMute.exe</TargetFilename>
+				<TargetFilename condition="end with">CommFunc.dll</TargetFilename>
+				<TargetFilename condition="end with">CommFunc.jax</TargetFilename>
+				<TargetFilename condition="end with">DESqmWrapper.dll</TargetFilename>
+				<TargetFilename condition="end with">DESqmWrapper.wrapper</TargetFilename>
+				<TargetFilename condition="end with">FSPMAPI.dll.fsp</TargetFilename>
+				<TargetFilename condition="end with">FSPMAPI.dll</TargetFilename>
+				<TargetFilename condition="end with">Gadget.exe</TargetFilename>
+				<TargetFilename condition="end with">LoLTWLauncher.exe</TargetFilename>
+				<TargetFilename condition="end with">Mc.exe</TargetFilename>
+				<TargetFilename condition="end with">McUtil.dll.ping</TargetFilename>
+				<TargetFilename condition="end with">McUtil.dll.url</TargetFilename>
+				<TargetFilename condition="end with">McUtil.dll</TargetFilename>
+				<TargetFilename condition="end with">MpSvc.dll</TargetFilename>
+				<TargetFilename condition="end with">MsMpEng.exe</TargetFilename>
+				<TargetFilename condition="end with">NtUserEx.dat</TargetFilename>
+				<TargetFilename condition="end with">NtUserEx.dat</TargetFilename>
+				<TargetFilename condition="end with">NtUserEx.dll</TargetFilename>
+				<TargetFilename condition="end with">NtUserEx.dll</TargetFilename>
+				<TargetFilename condition="end with">NvSmart.exe</TargetFilename>
+				<TargetFilename condition="end with">NvSmartMax.dll</TargetFilename>
+				<TargetFilename condition="end with">NvSmartMax.dll</TargetFilename>
+				<TargetFilename condition="end with">NvSmartMaxapp.dll</TargetFilename>
+				<TargetFilename condition="end with">OInfo11.ISO</TargetFilename>
+				<TargetFilename condition="end with">OInfo11.ocx</TargetFilename>
+				<TargetFilename condition="end with">OInfoP11.exe</TargetFilename>
+				<TargetFilename condition="end with">OleView.exe</TargetFilename>
+				<TargetFilename condition="end with">OleView.exe</TargetFilename>
+				<TargetFilename condition="end with">POETWLauncher.exe</TargetFilename>
+				<TargetFilename condition="end with">RasTls.dll.config</TargetFilename>
+				<TargetFilename condition="end with">RasTls.dll.msc</TargetFilename>
+				<TargetFilename condition="end with">RasTls.dll</TargetFilename>
+				<TargetFilename condition="end with">RasTls.exe</TargetFilename>
+				<TargetFilename condition="end with">RunHelp.exe</TargetFilename>
+				<TargetFilename condition="end with">Sidebar.dll.doc</TargetFilename>
+				<TargetFilename condition="end with">Sidebar.dll</TargetFilename>
+				<TargetFilename condition="end with">Ushata.dll</TargetFilename>
+				<TargetFilename condition="end with">Ushata.exe</TargetFilename>
+				<TargetFilename condition="end with">Ushata.fox</TargetFilename>
+				<TargetFilename condition="end with">VeetlePlayer.exe</TargetFilename>
+				<TargetFilename condition="end with">boot.ldr</TargetFilename>
+				<TargetFilename condition="end with">chrome_frame_helper.dll.rom</TargetFilename>
+				<TargetFilename condition="end with">chrome_frame_helper.dll</TargetFilename>
+				<TargetFilename condition="end with">chrome_frame_helper.exe</TargetFilename>
+				<TargetFilename condition="end with">dvcemumanager.exe</TargetFilename>
+				<TargetFilename condition="end with">fsguidll.exe</TargetFilename>
+				<TargetFilename condition="end with">fslapi.dll.gui</TargetFilename>
+				<TargetFilename condition="end with">fslapi.dll</TargetFilename>
+				<TargetFilename condition="end with">fsstm.exe</TargetFilename>
+				<TargetFilename condition="end with">hccutils.dll.res</TargetFilename>
+				<TargetFilename condition="end with">hccutils.dll</TargetFilename>
+				<TargetFilename condition="end with">hha.dll.bak</TargetFilename>
+				<TargetFilename condition="end with">hha.dll</TargetFilename>
+				<TargetFilename condition="end with">hhc.exe</TargetFilename>
+				<TargetFilename condition="end with">hkcmd.exe</TargetFilename>
+				<TargetFilename condition="end with">iviewers.dll</TargetFilename>
+				<TargetFilename condition="end with">jli.dll</TargetFilename>
+				<TargetFilename condition="end with">libvlc.dll</TargetFilename>
+				<TargetFilename condition="end with">mPclient.dll</TargetFilename>
+				<TargetFilename condition="end with">mcf.ep</TargetFilename>
+				<TargetFilename condition="end with">mcf.exe</TargetFilename>
+				<TargetFilename condition="end with">mcupdui.exe</TargetFilename>
+				<TargetFilename condition="end with">mcut.exe</TargetFilename>
+				<TargetFilename condition="end with">mcutil.dll.bbc</TargetFilename>
+				<TargetFilename condition="end with">mcvsmap.exe</TargetFilename>
+				<TargetFilename condition="end with">msi.dll.dat</TargetFilename>
+				<TargetFilename condition="end with">msi.dll</TargetFilename>
+				<TargetFilename condition="end with">msseces.asm</TargetFilename>
+				<TargetFilename condition="end with">msseces.exe</TargetFilename>
+				<TargetFilename condition="end with">mtcReport.ktc</TargetFilename>
+				<TargetFilename condition="end with">rc.dll</TargetFilename>
+				<TargetFilename condition="end with">rc.exe</TargetFilename>
+				<TargetFilename condition="end with">rc.hlp</TargetFilename>
+				<TargetFilename condition="end with">sep_NE.exe</TargetFilename>
+				<TargetFilename condition="end with">sep_NE.slf</TargetFilename>
+				<TargetFilename condition="end with">tplcdclr.exe</TargetFilename>
+				<TargetFilename condition="end with">winmm.dll</TargetFilename>
+				<TargetFilename condition="end with">wts.chm</TargetFilename>
+				<TargetFilename condition="end with">credwiz.exe</TargetFilename>
+			</Rule>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">ssMUIDLL.dll</TargetFilename>
+			<TargetFilename name="Attack=T1574.002,Technique=Hijack Execution Flow: DLL Side-Loading,Tactic=Defense Evasion,Level=0,Desc=Finfisher Sideload Detection" condition="end with">aepic.dll</TargetFilename>
+			<TargetFilename name="Attack=T1574.002,Technique=Hijack Execution Flow: DLL Side-Loading,Tactic=Defense Evasion,Level=0,Desc=Finfisher Sideload Detection" condition="end with">ftllib.dll</TargetFilename>
+			<TargetFilename name="Attack=T1574.002,Technique=Hijack Execution Flow: DLL Side-Loading,Tactic=Defense Evasion,Level=0,Desc=Finfisher Sideload Detection" condition="end with">userenv.dll</TargetFilename>
+			<TargetFilename name="Attack=T1021.001,Technique=Remote Services: Remote Desktop Protocol,Tactic=Lateral Movement,Level=0,Desc=RDP Bitmap Cache" condition="contains">\Terminal Server Client\Cache\</TargetFilename>
+			<TargetFilename name="Attack=T1204,Technique=User Execution,Tactic=Execution,Forensic=Windows Prefetch Exec History" condition="begin with">C:\Windows\Prefetch</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">\\tsclient</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\ServiceProfiles\LocalService\AppData\Local\Temp\TfsStore\</TargetFilename>
+			<TargetFilename name="Attack=T1087,Technique=Account Discovery,Tactic=Discovery,Level=4,Alert=SharpDump bin,Risk=100" condition="end with">\Temp\debug.bin</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Temp\7z</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\AppPatch\Custom</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.chm</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.cpl</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">.mht</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Chrome\User Data\Default\Extensions\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.crx</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.appref-ms</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.gadget</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.JSE</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.exe</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.scf</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Exchange Server\ClientAccess\Owa\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">\Device\HarddiskVolumeShadowCopy</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">.zip\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.FON</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.FOT</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\System32\GroupPolicy\Machine\Scripts</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\System32\GroupPolicy\User\Scripts</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.iqy</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.ico</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.isp</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.msc</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.manifest</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">MEMORY.dmp</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.msi</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.cs</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.customDestinations-ms</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">C:\Windows\Minidump</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.PAF</TargetFilename>
+			<TargetFilename name="Attack=T1021.001,Technique=Remote Services: Remote Desktop Protocol,Tactic=Lateral Movement,Level=0,Desc=RDP Bitmap Cache" condition="end with">.bmc</TargetFilename>
+			<TargetFilename name="Attack=T1021.001,Technique=Remote Services: Remote Desktop Protocol,Tactic=Lateral Movement,Level=0,Desc=RDP" condition="end with">.rdp</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.rtf</TargetFilename> 
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.reg</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.SHS</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.slk</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.SCR</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.set</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.SettingContent-ms</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.SHD</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.SPL</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.scr</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">HammerDrillStatus.dll</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Microsoft\Windows\WER\</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.ICL</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.sdb</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.SCT</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.SHB</TargetFilename>
+			<TargetFilename name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Temp\Temp1_</TargetFilename>
+			<!--Uncategorized-->
+			<TargetFilename condition="contains all">\Microsoft\;CLR_v;\UsageLogs\</TargetFilename>
+			<TargetFilename condition="end with">.ade</TargetFilename>
+			<TargetFilename condition="end with">.adp</TargetFilename>
+			<TargetFilename condition="end with">.application</TargetFilename>
+			<TargetFilename condition="end with">.appref-ms</TargetFilename>
+			<TargetFilename condition="end with">.asc</TargetFilename>
+			<TargetFilename condition="end with">.bmf</TargetFilename>
+			<TargetFilename condition="end with">.cer</TargetFilename>
+			<TargetFilename condition="end with">.dmp</TargetFilename>
+			<TargetFilename condition="end with">.gpg</TargetFilename>
+			<TargetFilename condition="end with">.htm</TargetFilename>
+			<TargetFilename condition="end with">.html</TargetFilename>
+			<TargetFilename condition="end with">.json</TargetFilename>
+			<TargetFilename condition="end with">.jsp</TargetFilename>
+			<TargetFilename condition="end with">.key</TargetFilename>
+			<TargetFilename condition="end with">.mof</TargetFilename>
+			<TargetFilename condition="end with">.ocx</TargetFilename>
+			<TargetFilename condition="end with">.p7b</TargetFilename>
+			<TargetFilename condition="end with">.p12</TargetFilename>
+			<TargetFilename condition="end with">.pem</TargetFilename>
+			<TargetFilename condition="end with">.pfx</TargetFilename>
+			<TargetFilename condition="end with">.pgp</TargetFilename>
+			<TargetFilename condition="end with">.php</TargetFilename>
+			<TargetFilename condition="end with">.ppk</TargetFilename>
+			<TargetFilename condition="end with">.war</TargetFilename>
+			<TargetFilename condition="end with">.xml</TargetFilename>
+		</FileCreate>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 12 & 13 & 14 : REGISTRY MODIFICATION [RegistryEvent]-->
+	<RuleGroup name="RG=RegistryEvent Include Group" groupRelation="or">
+		<RegistryEvent onmatch="include">
+			<!--MITRE ATT&CK TACTIC: Reconnaissance-->
+			<!--MITRE ATT&CK TECHNIQUE: Active Scanning-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Host Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Identity Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Network Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Gather Victim Org Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Phishing for Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Closed Sources-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Open Technical Databases-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Open Websites/Domains-->
+			<!--MITRE ATT&CK TECHNIQUE: Search Victim-Owned Websites-->
+
+			<!--MITRE ATT&CK TACTIC: Resource Development-->
+			<!--MITRE ATT&CK TECHNIQUE: Acquire Infrastructure-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Infrastructure-->
+			<!--MITRE ATT&CK TECHNIQUE: Develop Capabilities-->
+			<!--MITRE ATT&CK TECHNIQUE: Establish Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Obtain Capabilities-->
+			<!--MITRE ATT&CK TECHNIQUE: Stage Capabilities-->
+
+			<!--MITRE ATT&CK TACTIC: Initial Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Drive-by Compromise-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploit Public-Facing Application-->
+			<!--MITRE ATT&CK TECHNIQUE: External Remote Services-->
+			<Rule name="Forensic=RDP Connection History Tracking" groupRelation="and">
+				<TargetObject condition="contains">\Software\Microsoft\Terminal Server Client</TargetObject>
+				<TargetObject condition="excludes">DefaultPrinter</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Hardware Additions-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">MountedDevices</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Mountpoints2</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Active Setup\Installed Components</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Class\{4d36e96b-e325-11ce-bfc1-08002be10318}</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Class\{745a17a0-74d3-11d0-b6fe-00a0c90f57da}</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Class\{4d36e96f-e325-11ce-bfc1-08002be10318}</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Class\{36fc9e60-c465-11cf-8056-444553540000}</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Class\{e0cbf06c-cd8b-4647-bb8a-263b43f0f974}</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Class\{4d36e967-e325-11ce-bfc1-08002be10318}</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Class\{eec5ad98-8080-425f-922a-dabf3de3f69a}</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Class\{53D29EF7-377C-4D14-864B-EB3A85769359}</TargetObject>
+			<!--MITRE ATT&CK TECHNIQUE: Phishing-->
+			<!--MITRE ATT&CK TECHNIQUE: Replication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Supply Chain Compromise-->
+			<!--MITRE ATT&CK TECHNIQUE: Trusted Relationship-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts -->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\LogonUI\SessionData\</TargetObject>
+				<TargetObject condition="end with">LoggedOnUser</TargetObject>
+			</Rule>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">LastLoggedOnUser</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">LastLoggedOnProvider</TargetObject>
+			<!--MITRE ATT&CK TACTIC: Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Command and Scripting Interpreter-->
+			<!--MITRE ATT&CK TECHNIQUE: Container Administration Command-->
+			<!--MITRE ATT&CK TECHNIQUE: Deploy Container-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Client Execution-->
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=Suspicious Set Value of MSDT in Registry: Dogwalk/follina,Risk=100,CVE=CVE-2022-30190" groupRelation="and">
+				<TargetObject condition="begin with">HKCR\ms-msdt\</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=Scripted Diagnostics Turn Off Check Enabled: Dogwalk/follina,Risk=100,CVE=CVE-2022-30190" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Policies\Microsoft\Windows\ScriptedDiagnostics\TurnOffCheck</TargetObject>
+				<Details condition="contains">DWORD (0x00000001)</Details>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Inter-Process Communication-->
+			<!--MITRE ATT&CK TECHNIQUE: Native API-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<!--MITRE ATT&CK TECHNIQUE: Shared Modules-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Deployment Tools-->
+			<!--MITRE ATT&CK TECHNIQUE: System Services-->
+			<Rule name="Attack=T1543.003,Tactic=Persistence,Technique=Create Windows Service,Level=3,Alert=New SVCHost service,Risk=70" groupRelation="and">
+				<TargetObject condition="contains">SOFTWARE\Microsoft\Windows NT\CurrentVersion\Svchost</TargetObject>
+				<TargetObject condition="excludes">\print\</TargetObject>
+				<TargetObject condition="excludes">\AzureAttestService\CoInitializeSecurityParam</TargetObject>
+				<Image condition="excludes">C:\$WINDOWS.~BT\</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: User Execution-->
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=3,Alert=VBA Project Object Model Macro Settings,Risk=30" groupRelation="and">
+				<TargetObject condition="end with">\AccessVBOM</TargetObject>
+				<Image condition="excludes any">C:\Windows\system32\svchost.exe;C:\WINDOWS\system32\mmc.exe;C:\Windows\system32\userinit.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=3,Alert=VBA Project VBA Warnings Macro Setting Change,Risk=40" groupRelation="and">
+				<TargetObject condition="end with">Security\VBAWarnings</TargetObject>
+				<Image condition="excludes any">C:\Windows\system32\svchost.exe;C:\WINDOWS\system32\mmc.exe;C:\Windows\system32\userinit.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=3,Alert=VBA Project VBA Warnings Macro Setting Change,Risk=40" groupRelation="and">
+				<TargetObject condition="end with">Security\VBAWarnings</TargetObject>
+				<Image condition="excludes any">C:\Windows\system32\svchost.exe;C:\WINDOWS\system32\mmc.exe;C:\Windows\system32\userinit.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1204,Technique=User Execution,Tactic=Execution,Level=0,Desc=Potential Office Macro Execution Detected" groupRelation="and">
+				<Image condition="contains any">EXCEL.exe;WINWORD.exe</Image>
+				<TargetObject condition="contains any">{8BD21D32-EC42-11CE-9E0D-00AA006002F3};{5B9D8FC8-4A71-101B-97A6-00000B65C08B}</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: User Execution: Malicious File-->
+			<Rule name="Attack=T0000,Level=4,Alert=NJRAT Detection,Risk=100" groupRelation="and">
+				<TargetObject condition="is">HKCU\di</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">HKCU\�</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="or">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\AMSI\Providers\</TargetObject>
+				<TargetObject condition="begin with">hklm\software\microsoft\windows script\settings\amsienable</TargetObject>
+				<TargetObject condition="begin with">hkcu\software\microsoft\windows script\settings\amsienable</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Windows Management Instrumentation-->
+
+			<!--MITRE ATT&CK TACTIC: Persistence-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">Google\Chrome\Extensions</TargetObject>
+				<TargetObject condition="end with">update_url</TargetObject>
+				<EventType condition="is">SetValue</EventType>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Account Manipulation-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">ForcePasswordReset</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SECURITY\Policy\Secrets\$MACHINE.ACC\CurrVal</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SAM\SAM\DOMAINS\Account\Users\</TargetObject>
+				<TargetObject condition="end with">Last Password Change</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SAM\SAM\DOMAINS\Account\Users\</TargetObject>
+				<TargetObject condition="end with">Account Expiration</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SAM\SAM\DOMAINS\Account\Users\</TargetObject>
+				<TargetObject condition="end with">Last Failed Logon</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SAM\SAM\Domains\Builtin\Aliases\00000220\</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SAM\SAM\Domains\Builtin\Aliases\0000022B\</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: BITS Jobs-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Autostart Execution-->
+			<TargetObject name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Alert=Process Injection: injecting a 64-bit DLL into a 32-bit process" condition="contains">SOFTWARE\Microsoft\Wow64\x86\</TargetObject> <!-- http://www.hexacorn.com/blog/2019/07/11/beyond-good-ol-run-key-part-108-2/ -->
+			<Rule name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Alert=AutoRun Reg Keys,Risk=70" groupRelation="and">
+				<EventType condition="is">SetValue</EventType>
+				<TargetObject condition="contains">\CurrentVersion\Run\</TargetObject>
+				<Image condition="excludes">Add_exclusions_here</Image>
+			</Rule>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Logon Logoff Shutdown Scripts" condition="contains">\Microsoft\System\Scripts</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Logon Logoff Shutdown Scripts" condition="contains">\Windows\System\Scripts</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Service Command Line parameters" condition="begin with">HKLM\SYSTEM\Setup\CmdLine</TargetObject>
+			<Rule name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=1,Desc=Service Start Mode Changed to: Boot" groupRelation="and">
+				<TargetObject condition="end with">\Start</TargetObject>
+				<Details condition="contains">DWORD (0x00000000)</Details>
+			</Rule>
+			<Rule name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=1,Desc=Service Start Mode Changed to: System" groupRelation="and">
+				<TargetObject condition="end with">\Start</TargetObject>
+				<Details condition="contains">DWORD (0x00000001)</Details>
+			</Rule>
+			<Rule name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=1,Desc=Service Start Mode Changed to: Automatic" groupRelation="and">
+				<TargetObject condition="end with">\Start</TargetObject>
+				<Details condition="contains">DWORD (0x00000002)</Details>
+			</Rule>
+			<Rule name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Service Start Mode Changed to: Manual" groupRelation="and">
+				<TargetObject condition="end with">\Start</TargetObject>
+				<Details condition="contains">DWORD (0x00000003)</Details>
+			</Rule>
+			<Rule name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Service Start Mode Changed to: Disabled" groupRelation="and">
+				<TargetObject condition="end with">\Start</TargetObject>
+				<Details condition="contains">DWORD (0x00000004)</Details>
+			</Rule>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Services and autoruns imagepath" condition="end with">\ImagePath</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Windows Service DLL changes" condition="end with">\ServiceDll</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Manifest pointing to service's DLL" condition="end with">\ServiceManifest</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Run Keys,Tactic=Persistence" condition="begin with">hkcu\software\microsoft\windows nt\currentversion\windows\run\</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Run Keys,Tactic=Persistence" condition="begin with">hkcu\software\microsoft\windows\currentversion\explorer\shell folders\common startup</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Run Keys,Tactic=Persistence" condition="begin with">hkcu\software\microsoft\windows\currentversion\explorer\shell folders\startup</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Run Keys,Tactic=Persistence" condition="begin with">hklm\software\microsoft\command processor\autorun</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Run Keys,Tactic=Persistence" condition="contains all">hkcu\software\microsoft\windows nt\currentversion\accessibility\ATs\\*(1)\StartExe</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Run Keys,Tactic=Persistence" condition="contains">Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders\Startup</TargetObject>
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Autostart Execution: Print Processors-->
+			<TargetObject name="Attack=T1013,Technique=Port Monitors,Tactic=Persistence/Privilege Escalation" condition="contains">\Print\Monitors</TargetObject>
+			<!--<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Printers\Connections</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Print\Environments\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Servers\Printers\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Print\V4 Connections</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">CurrentVersion\PrinterPorts</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">SWD\PRINTENUM</TargetObject>-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Initialization Scripts-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Extensions-->
+			<!--MITRE ATT&CK TECHNIQUE: Compromise Client Software Binary-->
+			<!--MITRE ATT&CK TECHNIQUE: Create Account-->
+			<Rule name="Attack=T1136,Technique=Create Account,Tactic=Persistence,Level=0,Desc=New user created,Risk=40" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SAM\SAM\DOMAINS\Account\Users\Names\</TargetObject>
+				<TargetObject condition="excludes">$</TargetObject>
+				<EventType condition="is">CreateKey</EventType>
+			</Rule>
+			<Rule name="Attack=T1136,Technique=Create Account,Tactic=Persistence,Level=0,Desc=Hidden New user created,Risk=40" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SAM\SAM\DOMAINS\Account\Users\Names\</TargetObject>
+				<TargetObject condition="contains">$</TargetObject>
+				<EventType condition="is">CreateKey</EventType>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Create or Modify System Process-->
+			<Rule name="Level=3,Alert=Sysmon Manifest change detected,Risk=30" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\Microsoft\Windows\CurrentVersion\WINEVT\Publishers\{5770385f-c22a-43e0-bf4c-06f5698ffbd9}</TargetObject>
+				<Image condition="excludes">C:\WINDOWS\sysmon64.exe</Image>
+				<Image condition="excludes">C:\WINDOWS\sysmon.exe</Image>
+				<Image condition="excludes">C:\Programdata\sysmon\sysmon64.exe</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Event Triggered Execution-->
+			<Rule name="Attack=T1546.001,Technique=Event Triggered Execution: Change Default File Association,Tactic=Persistence,Level=0,Desc=Monitor Endpoint Protocol Handlers" groupRelation="and">
+				<TargetObject condition="begin with">HKCR\</TargetObject>
+				<TargetObject condition="end with">(Default)</TargetObject>
+				<TargetObject condition="excludes">\shell\open\command\(Default)</TargetObject>
+				<Details condition="begin with">URL:</Details>
+			</Rule>
+			<Rule name="Attack=T1546.001,Technique=Event Triggered Execution: Change Default File Association,Tactic=Persistence,Level=0,Desc=Monitor User Protocol Handlers" groupRelation="and">
+				<TargetObject condition="begin with">HKCU\Software\Classes\</TargetObject>
+				<TargetObject condition="end with">(Default)</TargetObject>
+				<TargetObject condition="excludes">\shell\open\command\(Default)</TargetObject>
+				<Details condition="begin with">URL:</Details>
+			</Rule>
+			<Rule name="Attack=T1546.001,Technique=Event Triggered Execution: Change Default File Association,Tactic=Persistence,Level=0,Desc=Monitor Endpoint File Associations" groupRelation="and">
+				<TargetObject condition="begin with">HKCR\</TargetObject>
+				<TargetObject condition="end with">\shell\open\command\(Default)</TargetObject>
+				<Details condition="contains">%1</Details>
+			</Rule>
+			<Rule name="Attack=T1546.001,Technique=Event Triggered Execution: Change Default File Association,Tactic=Persistence,Level=0,Desc=Monitor User Default File Associations" groupRelation="and">
+				<TargetObject condition="begin with">HKCU\Software\Classes\</TargetObject>
+				<TargetObject condition="end with">\shell\open\command\(Default)</TargetObject>
+				<Details condition="contains">%1</Details>
+			</Rule>
+			<Rule name="Attack=T1546.001,Technique=Event Triggered Execution: Change Default File Association,Tactic=Persistence,Level=0,Desc=Monitor COM Hijacking" groupRelation="and">
+				<TargetObject condition="end with">\shell\open\command\DelegateExecute</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Event Triggered Execution: Accessibility Features-->
+			<Rule name="Attack=T1015,Technique=Accessibility Features,Tactic=Persistence/Privilege Escalation,Level=3,Alert=Utilman Priv Escalation,Risk=100" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\utilman.exe</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1015,Technique=Accessibility Features,Tactic=Persistence/Privilege Escalation,Level=3,Alert=sethc.exe Priv Escalation,Risk=100" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\sethc.exe</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: External Remote Services-->
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Session Manager\KnownDlls</TargetObject>
+			<!--MITRE ATT&CK TECHNIQUE: Implant Internal Image-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Office Application Startup-->
+			<Rule name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence,Level=0,Desc=Microsoft Outlook Addins" groupRelation="and">
+				<TargetObject condition="contains">Outlook\Addins</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence,Level=0,Desc=Microsoft Word Addins" groupRelation="and">
+				<TargetObject condition="contains">Word\Addins</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence,Level=0,Desc=Microsoft Excel Addins" groupRelation="and">
+				<TargetObject condition="contains">Excel\Addins</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence,Level=0,Desc=Microsoft Powerpoint Addins" groupRelation="and">
+				<TargetObject condition="contains">Powerpoint\Addins</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence,Level=0,Desc=Microsoft VSTO Inclusions" groupRelation="and">
+				<TargetObject condition="contains">Software\Microsoft\VSTO\Security\Inclusion\</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence,Level=0,Desc=Microsoft VSTO Solution Metadata" groupRelation="and">
+				<TargetObject condition="contains">Software\Microsoft\VSTO\SolutionMetadata\</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Pre-OS Boot-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<!--MITRE ATT&CK TECHNIQUE: Server Software Component-->
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+
+			<!--MITRE ATT&CK TACTIC: Privilege Escalation-->
+			<!--MITRE ATT&CK TECHNIQUE: Abuse Elevation Control Mechanism-->
+			<Rule name="Attack=T1548,Tactic=Defense Evasion,Technique=Abuse Elevation Control Mechanism,Level=0,Desc=CMSTPLUA UAC Bypass" groupRelation="and">
+				<TargetObject condition="contains any">cmmgr32.exe</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Access Token Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Autostart Execution-->
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLU\Software\Microsoft\Command Processor\AutoRun</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\System\CurrentControlSet\Control\Session Manager\SetupExecute</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\System\CurrentControlSet\Control\Session Manager\Execute</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\Software\Wow6432Node\Microsoft\Command Processor\AutoRun</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\Software\Wow6432Node\Microsoft\Command Processor\AutoRun</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\Software\Microsoft\WindowsNT\CurrentVersion\Winlogon</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\Shell</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\Software\Microsoft\Windows NT\CurrentVersion\AeDebug</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\Software\Microsoft\Command Processor\AutoRun</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\BootExecute</TargetObject> <!--Microsoft:Windows: Autorun | Credit @ion-storm | [ https://www.cylance.com/windows-registry-persistence-part-2-the-run-keys-and-search-order ] -->
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\SafeDllSearchMode</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\VmApplet</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Userinit\</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify\</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\AppSetup</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=3,Alert=AutoRun Keys,Risk=70" condition="contains">UserInitMprLogonScript</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=BootVerificationProgram Autorun" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\BootVerificationProgram\ImagePath</TargetObject>
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Autostart Execution: Security Support Provider-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\System\CurrentControlSet\Control\Lsa\Authentication Packages</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\System\CurrentControlSet\Control\Lsa\Notification Packages</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Lsa\Security Packages</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\System\CurrentControlSet\Control\Lsa\OSConfig\Authentication Packages</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\System\CurrentControlSet\Control\Lsa\OSConfig\Notification Packages</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Lsa\OSConfig\Security Packages</TargetObject>
+			<!--MITRE ATT&CK TECHNIQUE: Boot or Logon Initialization Scripts-->
+			<!--MITRE ATT&CK TECHNIQUE: Create or Modify System Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Policy Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Escape to Host-->
+			<!--MITRE ATT&CK TECHNIQUE: Event Triggered Execution-->
+			<!--Microsoft:Windows:COM Object Hijacking [ https://blog.gdatasoftware.com/2014/10/23941-com-object-hijacking-the-discreet-way-of-persistence ] | Credit @ion-storm -->
+			<Rule name="Attack=T1546.015,Technique=Event Triggered Execution,Tactic=Defense Evasion,Level=3,Alert=Suspicious Com Object Hijacking Locations,Risk=30" groupRelation="and">
+				<TargetObject condition="contains any">\InprocServer32\(Default);\LocalServer32\(Default);\ScriptletURL\(Default)</TargetObject>
+				<Details condition="contains any">C:\Users\Public\;$Recyclebin;\temp\;\Desktop\;\Downloads\;\Content.Outlook\;\Microsoft\Office\</Details>
+				<Details condition="excludes">C:\WINDOWS\SYSTEM32\UpdateDeploy.dll</Details>
+			</Rule>
+			<Rule name="Attack=T1546.015,Technique=Event Triggered Execution,Tactic=Defense Evasion,Level=1,Desc=Com Object Hijacking Locations,Risk=30" groupRelation="and">
+				<TargetObject condition="contains any">\InprocServer32\(Default);\LocalServer32\(Default);\ScriptletURL\(Default)</TargetObject>
+				<Details condition="excludes">C:\WINDOWS\SYSTEM32\UpdateDeploy.dll</Details>
+			</Rule>
+			<Rule name="Attack=T1546.015,Technique=Event Triggered Execution,Tactic=Defense Evasion,Level=1,Desc=TreatAs/ProgID Friendly Name Com Hijacking Evasion - check for following rundll32 -sta,Risk=30" groupRelation="and">
+				<TargetObject condition="contains any">\ProgID\(Default);\TreatAs\(Default)</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Event Triggered Execution: Image File Execution Options Injection-->
+			<Rule name="Attack=T1183,Technique=Image File Execution Options Injection,Tactic=Defense Evasion,Level=1,Alert=Image File Execution Options,Risk=30" groupRelation="and">
+				<TargetObject condition="contains">\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\</TargetObject>
+				<TargetObject condition="contains any">Debugger;ReportingMode;MonitorProcess</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1183,Technique=Image File Execution Options Injection,Tactic=Defense Evasion,Level=0,Alert=SilentProcessExit Globalflag Set,Risk=75" groupRelation="and">
+				<TargetObject condition="contains">\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\</TargetObject>
+				<TargetObject condition="contains">GlobalFlag</TargetObject>
+				<Details condition="contains">DWORD (0x00000200)</Details> <!--SilentProcessExit Dword Value-->
+			</Rule>
+			<Rule name="Attack=T1183,Technique=Image File Execution Options Injection,Tactic=Privilege Escalation/Persistence/Defense Evasion,Level=0,Alert=SilentProcessExit Process Execution entry,Risk=100" groupRelation="and">
+				<TargetObject condition="contains">\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\</TargetObject>
+				<TargetObject condition="contains">MonitorProcess</TargetObject> <!--SilentProcessExit Monitor Process from werfault-->
+			</Rule>
+			<Rule name="Attack=T1183,Technique=Image File Execution Options Injection,Tactic=Privilege Escalation/Persistence/Defense Evasion,Level=0,Alert=SilentProcessExit Reporting Mode Enabled - Check for Child processes of werfault.exe,Risk=100" groupRelation="and">
+				<TargetObject condition="contains">\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\</TargetObject>
+				<TargetObject condition="contains">ReportingMode</TargetObject>
+				<Details condition="contains">DWORD (0x00000001)</Details> <!--SilentProcessExit Reporting Mode Enabled-->
+			</Rule>
+			<Rule name="Attack=T1183,Technique=Image File Execution Options Injection,Tactic=Privilege Escalation/Persistence/Defense Evasion,Level=0,Alert=SilentProcessExit Process Added,Risk=100" groupRelation="and">
+				<TargetObject condition="contains">\Microsoft\Windows NT\CurrentVersion\SilentProcessExit</TargetObject>
+				<EventType condition="is">CreateKey</EventType>
+			</Rule>
+			<Rule name="Attack=T1546,Technique=Event Triggered Execution,Tactic=Persistence,Level=3,Alert=Monitor Runtime Exeption Handler execution on crash,Risk=100" groupRelation="and">
+				<TargetObject condition="contains">\Microsoft\Windows\Windows Error Reporting\RuntimeExceptionHelperModules\</TargetObject>
+				<Image condition="excludes all">C:\Program Files (x86)\Microsoft\EdgeUpdate\Install\{;}\EDGEMITMP_;.tmp\setup.exe</Image>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Privilege Escalation-->
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Injection-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Task/Job-->
+			<Rule name="Attack=T1053,Technique=Scheduled Task,Tactic=Persistence,Level=3,Alert=New Scheduled Task Created,Risk=80" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree</TargetObject>
+				<TargetObject condition="end with">SD</TargetObject>
+				<TargetObject condition="excludes any">Microsoft\Windows\UpdateOrchestrator</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree</TargetObject>
+				<TargetObject condition="end with">ID</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tasks</TargetObject>
+				<TargetObject condition="end with">Author</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tasks</TargetObject>
+				<TargetObject condition="end with">Path</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tasks</TargetObject>
+				<TargetObject condition="end with">Date</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Logon</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Boot</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+
+			<!--MITRE ATT&CK TACTIC: Defense Evasion-->
+			<Rule name="Attack=T0000,Technique=Environment Value Modification,Tactic=Defense Evasion/Privilege Escalation,Level=0,Desc=Environment Value Modification" groupRelation="and">
+				<EventType condition="is">SetValue</EventType>
+				<TargetObject condition="contains">\Environment\</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Abuse Elevation Control Mechanism-->
+			<!--MITRE ATT&CK TECHNIQUE: Abuse Elevation Control Mechanism: Bypass User Account Control-->
+			<Rule name="Attack=T1548.002,Technique=Abuse Elevation Control Mechanism: Bypass User Account Control,Tactic=Defense Evasion,Level=4,Alert=UAC Disablement Detected" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System\EnableLUA</TargetObject>
+				<Details condition="contains">DWORD (0x00000000)</Details>
+			</Rule>
+			<Rule name="Attack=T1548.002,Technique=Abuse Elevation Control Mechanism: Bypass User Account Control,Tactic=Defense Evasion,Level=4,Alert=ConsentPromptBehaviorAdmin Disablement Detected" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System\ConsentPromptBehaviorAdmin</TargetObject>
+				<Details condition="contains">DWORD (0x00000000)</Details>
+			</Rule>
+			<Rule name="Attack=T1548.002,Technique=Abuse Elevation Control Mechanism: Bypass User Account Control,Tactic=Defense Evasion,Level=4,Alert=PromptOnSecureDesktop Disablement Detected" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System\PromptOnSecureDesktop</TargetObject>
+				<Details condition="contains">DWORD (0x00000000)</Details>
+			</Rule>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy</TargetObject>
+			<TargetObject name="Attack=T1088,Technique=Bypass User Account Control,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=UAC Bypass,Risk=70" condition="end with">\Software\Microsoft\Windows\CurrentVersion\App Paths\control.exe</TargetObject>
+			<TargetObject name="Attack=T1088,Technique=Bypass User Account Control,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=UAC Bypass,Risk=70" condition="end with">exefile\shell\runas\command\isolatedCommand</TargetObject>			
+			<!--MITRE ATT&CK TECHNIQUE: Access Token Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: BITS Jobs-->
+			<!--MITRE ATT&CK TECHNIQUE: Build Image on Host-->
+			<!--MITRE ATT&CK TECHNIQUE: Debugger Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Deobfuscate/Decode Files or Information-->
+			<!--MITRE ATT&CK TECHNIQUE: Deploy Container-->
+			<!--MITRE ATT&CK TECHNIQUE: Direct Volume Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Policy Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Execution Guardrails-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Defense Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: File and Directory Permissions Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Hide Artifacts-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\Hidden</TargetObject>
+			<Rule name="Attack=T1564.002,Technique=Hide Artifacts: Hidden Users,Tactic=Defense Evasion,Level=4,Alert=User Account Hidden From Logon Screen,Risk=100" groupRelation="and">
+				<TargetObject condition="contains">SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\Userlist\</TargetObject>
+				<TargetObject condition="end with">$</TargetObject>
+ 				<Details condition="contains">DWORD (0x00000000)</Details>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Hijack Execution Flow-->
+			<!--MITRE ATT&CK TECHNIQUE: Impair Defenses-->
+			<Rule name="Attack=T1562,Technique=Impair Defenses,Tactic=Defense Evasion,Level=4,Alert=Stealth Sysmon Change Detected,Risk=100" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SYSTEM\CurrentControlSet\Services\SysmonDrv\Parameters</TargetObject>
+				<Image condition="excludes">C:\WINDOWS\sysmon64.exe</Image>
+				<Image condition="excludes">C:\WINDOWS\sysmon.exe</Image>
+				<Image condition="excludes">C:\Programdata\sysmon\sysmon64.exe</Image>
+				<!--Customize: Add your configuration dir above-->
+			</Rule>
+			<Rule name="Technique=Disabling Security Tools,Tactic=Defense Evasion,Attack=1089,Level=0,Desc=Modification to System Exploit Protection,Risk=30" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\kernel</TargetObject>
+				<TargetObject condition="contains any">MitigationOptions;MitigationAuditOptions</TargetObject>
+			</Rule>
+			<Rule name="Technique=Disabling Security Tools,Tactic=Defense Evasion,Attack=1089,Level=0,Desc=Modification to Per-Process Exploit Protection,Risk=30" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options</TargetObject>
+				<TargetObject condition="contains any">MitigationOptions;MitigationAuditOptions</TargetObject>
+				<TargetObject condition="excludes">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\vmcompute.exe\0\MitigationOptions</TargetObject>
+				<TargetObject condition="excludes">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\vmwp.exe\0\MitigationOptions</TargetObject>
+				<Image condition="excludes">msiexec.exe</Image>
+				<Image condition="excludes">TiWorker.exe</Image>
+			</Rule>
+			<Rule name="Technique=Disabling Security Tools,Tactic=Defense Evasion,Attack=1089,Level=4,Alert=Modification to WOW64 Per-Process Exploit Protection Mitigation Options,Risk=30" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\Image File Execution Options</TargetObject>
+				<TargetObject condition="contains any">MitigationOptions;MitigationAuditOptions</TargetObject>
+				<Image condition="excludes">C:\Program Files\Microsoft Office 15\root\integration\integrator.exe</Image>
+				<TargetObject condition="excludes">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Acro</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Impair Defenses: Disable or Modify Tools-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="end with">DisableTaskMgr</TargetObject>
+				<Image condition="excludes">C:\WINDOWS\system32\svchost.exe</Image>
+				<Image condition="excludes">C:\windows\SysWOW64\svchost.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1562.001,Technique=Impair Defenses: Disable or Modify Tools,Tactic=Defense Evasion,Level=4,Alert=Driver Altitude Change Detected - Causes Driver load failure on boot" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SYSTEM\CurrentControlSet\</TargetObject>
+				<TargetObject condition="contains all">\Instances\;Altitude</TargetObject>
+				<TargetObject condition="is not">HKLM\System\CurrentControlSet\Services\CldFlt\Instances\CldFlt\Altitude</TargetObject>
+				<EventType condition="is">SetValue</EventType>
+			</Rule>
+			<!--Detect Malware & Unauthorized Changes to Outlook, Excel, Powerpoint, and Access Security to enable execution of scripts/Macros -->
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=4,Alert=All Office Macros Enabled!,Risk=100" groupRelation="and">
+				<TargetObject condition="contains">\Security\Level</TargetObject>
+				<Details condition="contains">DWORD (0x00000001)</Details>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=1,Desc=Notifications for all macros,Risk=50" groupRelation="and">
+				<TargetObject condition="contains">\Security\Level</TargetObject>
+				<Details condition="contains">DWORD (0x00000002)</Details>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=0,Desc=Notifications for digitally signed macros - all other macros disabled,Risk=0" groupRelation="and">
+				<TargetObject condition="contains">\Security\Level</TargetObject>
+				<Details condition="contains">DWORD (0x00000003)</Details>
+			</Rule>
+			<Rule name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=0,Desc=All Office Macros Disabled without notification,Risk=0" groupRelation="and">
+				<TargetObject condition="contains">\Security\Level</TargetObject>
+				<Details condition="contains">DWORD (0x00000004)</Details>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">\Outlook\Security</TargetObject>
+				<!--Allow Outlook Details rules to fire-->
+				<TargetObject condition="excludes">\Security\Level</TargetObject>
+			</Rule>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Word\Security</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Excel\Security</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Security\Level1Remove</TargetObject>
+			<!--Detect if Microsoft Security Center is Disabled or Enabled-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\HideSCAHealth</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Security Center\AntiVirusDisableNotify</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Security Center\UacDisableNotify</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Security Center\DisableMonitoring</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Security Center\FirewallDisableNotify</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Security Center\UpdatesDisableNotify</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Security Center\FirewallOverride</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Security Center\AllAlertsDisabled</TargetObject>
+			<!--Detect if Windows Defender is Disabled-->
+			<TargetObject name="Technique=Disabling Security Tools,Tactic=Defense Evasion,Attack=1089,Level=4,Alert=Detected disablement of System Restore,Risk=70" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SystemRestore\RPSessionInterval</TargetObject>
+			<TargetObject name="Technique=Disabling Security Tools,Tactic=Defense Evasion,Attack=1089,Level=4,Alert=Detected disablement of System Restore,Risk=70" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SystemRestore\SystemRestorePointCreationFrequency</TargetObject>
+			<TargetObject name="Technique=Disabling Security Tools,Tactic=Defense Evasion,Attack=1089,Level=0,Desc=Detected disablement of machine password,Risk=70" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters\DisablePasswordChange</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters\FullSecureChannelProtection</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters\RefusePasswordChange</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\DisableAntiSpyware</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection\DisableBehaviorMonitoring</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection\DisableOnAccessProtection</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Spynet\SpyNetReporting</TargetObject>
+			<!--MITRE ATT&CK TECHNIQUE: Impair Defenses: Disable Windows Event Logging-->
+			<Rule name="Attack=T1070.001,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=Disabling of Windows Event Log Source,Risk=100" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WINEVT\</TargetObject>
+				<TargetObject condition="end with">\Enabled</TargetObject>
+				<Details condition="contains">DWORD (0x00000000)</Details>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WINEVT\</TargetObject>
+				<TargetObject condition="end with">\Enabled</TargetObject>
+				<Details condition="contains">DWORD (0x00000001)</Details>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WINEVT\</TargetObject>
+				<TargetObject condition="excludes">\Enabled</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1070.001,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=Disabling of Powershell Event Logging,Risk=100" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Policies\Microsoft\Windows\Powershell\ScriptBlockLogging</TargetObject>
+				<TargetObject condition="end with">\EnableScriptBlockLogging</TargetObject>
+				<Details condition="contains">DWORD (0x00000000)</Details>
+			</Rule>
+			<Rule name="Attack=T1070.001,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=Disabling of Powershell Event Logging,Risk=100" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Policies\Microsoft\Windows\Powershell\ScriptBlockLogging</TargetObject>
+				<TargetObject condition="end with">\EnableScriptBlockLogging</TargetObject>
+				<EventType condition="is any">DeleteKey;DeleteValue</EventType>
+			</Rule>
+			<Rule name="Attack=T1070.001,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=Disabling of cmdline Event Logging,Risk=100" groupRelation="and">
+				<TargetObject condition="begin with">hklm\software\microsoft\windows\currentversion\policies\system\audit</TargetObject>
+				<TargetObject condition="end with">\ProcessCreationIncludeCmdLine_Enabled</TargetObject>
+				<Details condition="contains">DWORD (0x00000000)</Details>
+			</Rule>
+			<Rule name="Attack=T1070.001,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=Disabling of cmdline Event Logging,Risk=100" groupRelation="and">
+				<TargetObject condition="begin with">hklm\software\microsoft\windows\currentversion\policies\system\audit</TargetObject>
+				<TargetObject condition="end with">\ProcessCreationIncludeCmdLine_Enabled</TargetObject>
+				<EventType condition="is any">DeleteKey;DeleteValue</EventType>
+			</Rule>
+			<Rule name="Attack=T1070.001,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=Eventlog Security Descriptor Modification,Risk=100" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\System\CurrentControlSet\Services\Eventlog</TargetObject>
+				<TargetObject condition="end with">\CustomSD</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1070.001,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=0,Desc=Eventlog Size Modification,Risk=100" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\System\CurrentControlSet\Services\Eventlog</TargetObject>
+				<TargetObject condition="end with">\MaxSize</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Impair Defenses: Disable or Modify System Firewall-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">globallyopenports</TargetObject>
+			</Rule>
+			<TargetObject name="Technique=Disabling Security Tools,Tactic=Defense Evasion,Attack=1089,Level=0,Desc=Monitor Firewall Enablement or Disablement" condition="end with">EnableFirewall</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\AuthorizedApplications\List</TargetObject>
+
+			<!--MITRE ATT&CK TECHNIQUE: Indicator Removal on Host-->
+			<Rule name="Attack=T1070,Technique=Impair Defenses: Indicator Removal on Host,Tactic=Defense Evasion,Level=3,Alert=ETWEnabled Env Tampering,Risk=70" groupRelation="and">
+				<TargetObject condition="contains">\Microsoft\.NETFramework\ETWEnabled</TargetObject>
+				<Details condition="contains">DWORD (0x00000000)</Details>
+			</Rule>
+			<Rule name="Attack=T1070,Technique=Impair Defenses: Indicator Removal on Host,Tactic=Defense Evasion,Level=3,Alert=Usagelog Tampering,Risk=70" groupRelation="and">
+				<TargetObject condition="contains">\Microsoft\.NETFramework\NGenAssemblyUsageLog</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1070,Technique=Impair Defenses: Indicator Removal on Host,Tactic=Defense Evasion,Level=3,Alert=Usagelog Env Tampering,Risk=70" groupRelation="and">
+				<EventType condition="is">SetValue</EventType>
+				<TargetObject condition="contains">\Environment\NGenAssemblyUsageLog</TargetObject>
+			</Rule>
+			<Rule name="Attack=T1070,Technique=Impair Defenses: Indicator Removal on Host,Tactic=Defense Evasion,Level=3,Alert=COMPlus_ETWEnabled Env Tampering,Risk=70" groupRelation="and">
+				<EventType condition="is">SetValue</EventType>
+				<TargetObject condition="contains">\Environment\COMPlus_ETWEnabled</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Indirect Command Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Masquerading-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Cloud Compute Infrastructure-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Registry-->
+			<Rule name="Forensic=Regedit history Detection,Risk=30" groupRelation="and">
+				<TargetObject condition="end with">\LastKey</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">SymbolicLinkValue</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">\Software\Microsoft\Windows\CurrentVersion\Explorer</TargetObject>
+				<Image condition="contains any">\AppData\;\ProgramData\;\Temp\;C:\users</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">&#x202e;</TargetObject>
+			</Rule>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\System\CurrentControlSet\Control\SecurePipeServers\winreg</TargetObject>
+
+			<!--MITRE ATT&CK TECHNIQUE: Modify System Image-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains any">\Software\Policies\Microsoft\SystemCertificates\;\SOFTWARE\Microsoft\EnterpriseCertificates\;HKLM\SOFTWARE\Microsoft\SystemCertificates\;HKLM\Software\Microsoft\Cryptography\Services\ServiceName\SystemCertificates\</TargetObject>
+				<EventType condition="is not">CreateKey</EventType>
+				<Image condition="excludes">C:\WINDOWS\Sysmon64.exe</Image>
+				<Image condition="excludes">C:\WINDOWS\Sysmon.exe</Image>
+				<Image condition="excludes">C:\WINDOWS\system32\certsrv.exe</Image>
+				<Image condition="excludes">C:\WINDOWS\system32\CompatTelRunner.exe</Image>
+				<Image condition="excludes">C:\WINDOWS\system32\svchost.exe</Image>
+				<Image condition="excludes">C:\Windows\SysWOW64\SearchProtocolHost.exe</Image>
+				<Image condition="excludes">C:\Windows\system32\SearchProtocolHost.exe</Image>
+				<Image condition="excludes">C:\Windows\system32\taskhost.exe</Image>
+				<Image condition="excludes">C:\windows\SysWOW64\svchost.exe</Image>
+				<Image condition="excludes">C:\WINDOWS\System32\DriverStore\FileRepository\asus</Image>
+				<Image condition="excludes">C:\ProgramData\Microsoft\Windows Defender\Platform\</Image>
+				<Image condition="excludes">C:\Program Files\ASUS\ARMOURY CRATE Service\ArmouryCrate.Service.exe</Image>
+				<Image condition="excludes">C:\Program Files\NVIDIA Corporation\NvContainer\nvcontainer.exe</Image>
+			</Rule>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">fDenyTSConnections</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Terminal Server\WinStations\RDP-Tcp</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">RDP-tcp\PortNumber</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">Control\Terminal Server\fSingleSessionPerUser</TargetObject>
+			<!--MITRE ATT&CK TECHNIQUE: Network Boundary Bridging-->
+			<!--MITRE ATT&CK TECHNIQUE: Obfuscated Files or Information-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">&#xfffd;</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains any">Й;ќ;Л;я;К</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Plist File Modification-->
+			<!--MITRE ATT&CK TECHNIQUE: Pre-OS Boot-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Injection-->
+			<!--MITRE ATT&CK TECHNIQUE: Reflective Code Loading-->
+			<!--MITRE ATT&CK TECHNIQUE: Rogue Domain Controller-->
+			<!--MITRE ATT&CK TECHNIQUE: Rootkit-->
+			<TargetObject name="Attack=T1109,Technique=Component Firmware,Tactic=Defense Escalation/Persistence,Level=0,Desc=Detect ACPI Rootkits" condition="begin with">HKLM\HARDWARE\ACPI\DSDT</TargetObject> <!--Detect ACPI Rootkits -->
+			<!--MITRE ATT&CK TECHNIQUE: Subvert Trust Controls-->
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: Regsvr32-->
+			<!--MITRE ATT&CK TECHNIQUE: System Binary Proxy Execution: MsiExec-->
+			<!--MITRE ATT&CK TECHNIQUE: System Script Proxy Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Template Injection-->
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Trusted Developer Utilities Proxy Execution-->
+			<!--MITRE ATT&CK TECHNIQUE: Unused/Unsupported Cloud Regions-->
+			<!--MITRE ATT&CK TECHNIQUE: Use Alternate Authentication Material-->
+			<!--MITRE ATT&CK TECHNIQUE: Valid Accounts-->
+			<!--MITRE ATT&CK TECHNIQUE: Virtualization/Sandbox Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Weaken Encryption-->
+			<!--MITRE ATT&CK TECHNIQUE: XSL Script Processing-->
+
+			<!--MITRE ATT&CK TACTIC: Credential Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Adversary-in-the-Middle-->
+			<!--MITRE ATT&CK TECHNIQUE: Brute Force-->
+			<!--MITRE ATT&CK TECHNIQUE: Credentials from Password Stores-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation for Credential Access-->
+			<!--MITRE ATT&CK TECHNIQUE: Forced Authentication-->
+			<!--MITRE ATT&CK TECHNIQUE: Forge Web Credentials-->
+			<!--MITRE ATT&CK TECHNIQUE: Input Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Modify Authentication Process-->
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Factor Authentication Interception-->
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Factor Authentication Request Generation-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Sniffing-->
+			<!--MITRE ATT&CK TECHNIQUE: OS Credential Dumping-->
+			<!--MITRE ATT&CK TECHNIQUE: Steal Application Access Token-->
+			<!--MITRE ATT&CK TECHNIQUE: Steal or Forge Kerberos Tickets-->
+			<!--MITRE ATT&CK TECHNIQUE: Steal Web Session Cookie-->
+			<!--MITRE ATT&CK TECHNIQUE: Unsecured Credentials-->
+			<!--MITRE ATT&CK TECHNIQUE: Unsecured Credentials: Credentials in Registry-->
+			<TargetObject condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\Account Name</TargetObject>
+			<TargetObject condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\Display Name</TargetObject>
+			<TargetObject condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\Email</TargetObject>
+			<TargetObject condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\HTTP User</TargetObject>
+			<TargetObject condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\IMAP User</TargetObject>
+			<TargetObject condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\MAPI Provider</TargetObject>
+			<TargetObject condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\POP3 User</TargetObject>
+			<TargetObject condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\SMTP User</TargetObject>
+			<TargetObject name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Level=4,Alert=Credentials in Registry,Level=4,Alert=Credentials in Registry: Password,Risk=100" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\DefaultPassword</TargetObject>
+			<TargetObject name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Level=4,Alert=Credentials in Registry,Level=4,Alert=Credentials in Registry: Password,Risk=100" condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\HTTP Password</TargetObject>
+			<TargetObject name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Level=4,Alert=Credentials in Registry,Level=4,Alert=Credentials in Registry: Password,Risk=100" condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\IMAP Password</TargetObject>
+			<TargetObject name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Level=4,Alert=Credentials in Registry,Level=4,Alert=Credentials in Registry: Password,Risk=100" condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\POP3 Password</TargetObject>
+			<TargetObject name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Level=4,Alert=Credentials in Registry,Level=4,Alert=Credentials in Registry: Password,Risk=100" condition="contains all">SOFTWARE\Microsoft\Office\;\Outlook\Profiles\;\9375CFF0413111d3B88A00104B2A6676\;\SMTP Password</TargetObject>
+			<TargetObject name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Desc=Credentials in Registry,Level=0,Desc=Credentials in Registry: Domain" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\DefaultDomainName</TargetObject>
+			<TargetObject name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Desc=Credentials in Registry,Level=0,Desc=Credentials in Registry: Username" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\DefaultUserName</TargetObject>
+			<TargetObject name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Level=4,Alert=Teamviewer Password Exposed in Plain Text 1,Risk=70" condition="contains">SecurityPasswordAES</TargetObject>
+			<TargetObject name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Level=4,Alert=Teamviewer Password Exposed in Plain Text 2,Risk=70" condition="contains">OptionsPasswordAES</TargetObject>
+			<TargetObject name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Level=4,Alert=Teamviewer Password Exposed in Plain Text 3,Risk=70" condition="contains">SecurityPasswordExported</TargetObject>
+			<TargetObject name="Attack=T1214,Technique=Credentials in Registry,Tactic=Credential Access,Level=4,Alert=Teamviewer Password Exposed in Plain Text 4,Risk=70" condition="contains">PermanentPassword</TargetObject>
+			<!--MITRE ATT&CK TACTIC: Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Account Discovery -->
+			<!--MITRE ATT&CK TECHNIQUE: Application Window Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Bookmark Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Infrastructure Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Service Dashboard-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Cloud Storage Object Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Container and Resource Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Debugger Evasion-->
+			<!--MITRE ATT&CK TECHNIQUE: Domain Trust Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: File and Directory Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Group Policy Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Share Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Network Sniffing-->
+			<!--MITRE ATT&CK TECHNIQUE: Password Policy Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Peripheral Device Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Permission Groups Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Process Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Query Registry-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote System Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Information Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Location Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Network Configuration Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Network Connections Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Owner/User Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Service Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: System Time Discovery-->
+			<!--MITRE ATT&CK TECHNIQUE: Virtualization/Sandbox Evasion-->
+
+			<!--MITRE ATT&CK TACTIC: Lateral Movement-->
+			<!--MITRE ATT&CK TECHNIQUE: Exploitation of Remote Services-->
+			<!--MITRE ATT&CK TECHNIQUE: Internal Spearphishing-->
+			<!--MITRE ATT&CK TECHNIQUE: Lateral Tool Transfer-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote Service Session Hijacking-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote Services-->
+
+			<!--MITRE ATT&CK TECHNIQUE: Replication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Software Deployment Tools-->
+			<!--MITRE ATT&CK TECHNIQUE: Taint Shared Content-->
+			<!--MITRE ATT&CK TECHNIQUE: Use Alternate Authentication Material-->
+
+			<!--MITRE ATT&CK TACTIC: Collection-->
+			<!--MITRE ATT&CK TECHNIQUE: Adversary-in-the-Middle-->
+			<!--MITRE ATT&CK TECHNIQUE: Archive Collected Data-->
+			<!--MITRE ATT&CK TECHNIQUE: Audio Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Automated Collection-->
+			<!--MITRE ATT&CK TECHNIQUE: Browser Session Hijacking-->
+			<!--MITRE ATT&CK TECHNIQUE: Clipboard Data-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Cloud Storage Object-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Configuration Repository-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Information Repositories-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Local System-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Network Shared Drive-->
+			<!--MITRE ATT&CK TECHNIQUE: Data from Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Staged-->
+			<!--MITRE ATT&CK TECHNIQUE: Email Collection-->
+			<!--MITRE ATT&CK TECHNIQUE: Input Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Screen Capture-->
+			<!--MITRE ATT&CK TECHNIQUE: Video Capture-->
+
+			<!--MITRE ATT&CK TACTIC: Command and Control-->
+			<!--MITRE ATT&CK TECHNIQUE: Application Layer Protocol-->
+			<!--MITRE ATT&CK TECHNIQUE: Communication Through Removable Media-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Encoding-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Obfuscation-->
+			<!--MITRE ATT&CK TECHNIQUE: Dynamic Resolution-->
+			<!--MITRE ATT&CK TECHNIQUE: Encrypted Channel-->
+			<!--MITRE ATT&CK TECHNIQUE: Fallback Channels-->
+			<!--MITRE ATT&CK TECHNIQUE: Ingress Tool Transfer-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\GitForWindows</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Multi-Stage Channels-->
+			<!--MITRE ATT&CK TECHNIQUE: Non-Application Layer Protocol-->
+			<!--MITRE ATT&CK TECHNIQUE: Non-Standard Port-->
+			<!--MITRE ATT&CK TECHNIQUE: Protocol Tunneling-->
+			<!--MITRE ATT&CK TECHNIQUE: Proxy-->
+			<!--MITRE ATT&CK TECHNIQUE: Remote Access Software-->
+			<!--MITRE ATT&CK TECHNIQUE: Traffic Signaling-->
+			<!--MITRE ATT&CK TECHNIQUE: Web Service-->
+
+			<!--MITRE ATT&CK TACTIC: Exfiltration-->
+
+			<!--MITRE ATT&CK TECHNIQUE: Automated Exfiltration-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Transfer Size Limits-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Alternative Protocol-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over C2 Channel-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Other Network Medium-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Physical Medium-->
+			<!--MITRE ATT&CK TECHNIQUE: Exfiltration Over Web Service-->
+			<!--MITRE ATT&CK TECHNIQUE: Scheduled Transfer-->
+			<!--MITRE ATT&CK TECHNIQUE: Transfer Data to Cloud Account-->
+			<!--MITRE ATT&CK TACTIC: Impact-->
+			<!--MITRE ATT&CK TECHNIQUE: Account Access Removal-->
+			<Rule name="Attack=T1531,Technique=Account Access Removal,Tactic=Impact,Level=1,Desc=User Account Deleted" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SAM\SAM\DOMAINS\Account\Users\Names\</TargetObject>
+				<EventType condition="is">DeleteKey</EventType>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Data Destruction-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Encrypted for Impact-->
+			<!--MITRE ATT&CK TECHNIQUE: Data Manipulation-->
+			<!--MITRE ATT&CK TECHNIQUE: Defacement-->
+			<!--MITRE ATT&CK TECHNIQUE: Disk Wipe-->
+			<!--MITRE ATT&CK TECHNIQUE: Endpoint Denial of Service-->
+			<!--MITRE ATT&CK TECHNIQUE: Firmware Corruption-->
+			<!--MITRE ATT&CK TECHNIQUE: Inhibit System Recovery-->
+			<Rule name="Attack=T1485,Technique=Inhibit System Recovery,Tactic=Impact,Level=0,Desc=VSS Disablement Detection,Risk=70" groupRelation="and">
+				<TargetObject condition="contains">\Services\VSS\Diag\(Default)</TargetObject>
+			</Rule>
+			<!--MITRE ATT&CK TECHNIQUE: Network Denial of Service-->
+			<!--MITRE ATT&CK TECHNIQUE: Resource Hijacking-->
+			<!--MITRE ATT&CK TECHNIQUE: Service Stop-->
+			<!--MITRE ATT&CK TECHNIQUE: System Shutdown/Reboot-->
+			<!-- UEBA/Uncategorized Detections-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SYSTEM\CurrentControlSet\Services\Lanmanworkstation\Parameters</TargetObject>
+			</Rule>
+			<Rule name="Forensic=Regedit history Detection,Risk=30" groupRelation="and">
+				<TargetObject condition="end with">\LastKey</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="end with">\WinStationsDisabled</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="end with">\TSServerDrainMode</TargetObject>
+			</Rule>
+			<Rule name="Forensic=IE history Detection" groupRelation="and">
+				<TargetObject condition="end with">\TypedURLs</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SYSTEM\CurrentControlSet\services\TCPIP6\Parameters\disabledcomponents</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SYSTEM\CurrentControlSet\Services\Tcpip6\Linkage\Bind</TargetObject>
+				<Details condition="excludes">Binary Data</Details>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\NetworkCards</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">services\http\parameters\urlaclinf</TargetObject>
+			</Rule>
+			<Rule name="Forensic=Adobe Recent File List History" groupRelation="and">
+				<TargetObject condition="contains">cRecentFiles\c1\</TargetObject>
+				<TargetObject condition="end with">tDIText</TargetObject>
+			</Rule>
+			<Rule name="Forensic=Office History MRU" groupRelation="and">
+				<TargetObject condition="end with">\File MRU\Item 1</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\System\CurrentControlSet\Services\SysmonDrv\Parameters\ConfigHash</TargetObject>
+			</Rule>
+			<!--Common Malware Persistence locations-->
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Registry AutoRun Keys,Risk=70" condition="begin with">HKLM\SOFTWARE\Classes\ CLSID\{73E709EA-5D93-4B2E-BBB0-99B7938DA9E4}\LocalServer32</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Registry AutoRun Keys,Risk=70" condition="begin with">HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Registry AutoRun Keys,Risk=70" condition="begin with">HKLM\Software\Microsoft\Windows\CurrentVersion\RunService</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Registry AutoRun Keys,Risk=70" condition="begin with">HKLM\Software\Microsoft\Windows\CurrentVersion\RunServicesOnce</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Registry AutoRun Keys,Risk=70" condition="contains">CurrentVersion\Windows\Load</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Registry AutoRun Keys,Risk=70" condition="contains">CurrentVersion\Windows\Run</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Registry AutoRun Keys,Risk=70" condition="contains">CurrentVersion\Winlogon\Shell</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Registry AutoRun Keys,Risk=70" condition="contains">CurrentVersion\Winlogon\System</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Registry AutoRun Keys,Risk=70" condition="contains">\Software\Microsoft\Windows NT\CurrentVersion\Windows\load</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Registry AutoRun Keys,Risk=70" condition="contains">\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=0,Desc=Registry AutoRun Keys,Risk=70" condition="contains">\Software\Microsoft\Windows\CurrentVersion\RunServicesOnce</TargetObject>
+			<TargetObject name="Attack=T1562.006,Technique=Impair Defenses: Indicator Blocking,Tactic=Defense Evasion,Level=0,Desc=ETW Tampering,Risk=70" condition="end with">SOFTWARE\Microsoft\.NETFramework\ETWEnabled</TargetObject>
+			<TargetObject condition="contains">\Group Policy\Scripts</TargetObject>
+			<TargetObject name="Attack=T1060,Technique=Registry Autorun Keys,Tactic=Persistence,Level=2,Alert=AutoRun Keys,Risk=70" condition="contains">Terminal Server\Wds\rdpwd\StartupPrograms</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Winlogon\AlternateShells\AvailableShells</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Policies\System\Shell</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Windows CE Services\AutoStartOnConnect</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Windows CE Services\AutoStartOnDisconnect</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">PreferenceMACs\Default\extensions.settings</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">CurrentVersion\URL</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\CurrentVersion\Font Drivers</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\Software\Microsoft\Windows\CurrentVersion\Group Policy\Scripts\Shutdown</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">CurrentVersion\Windows\IconServiceLib</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Active Setup\Installed Components</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">NullSessionShares</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">NullSessionPipes</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">PasswordExpiryNotification</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">SafeBoot\AlternateShell</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Desktop\Scrnsave.exe</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\DisplayVersion</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\ModifyPath</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Microsoft\Windows\CurrentVersion\Uninstall\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\UninstallString</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Terminal Server\WinStations\RDP-Tcp\InitialProgram</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Taskman</TargetObject>
+			<!--CLSID launch commands and file association changes-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Explorer\FileExts\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\shell\install\command\</TargetObject> <!--Microsoft:Windows: Sensitive subkey under file associations and CLSID that map to launch command-->
+			<TargetObject name="Forensic=User SID History for Forensics" condition="end with">\ProfileImagePath</TargetObject><!--Lets Get SID History and other info for Forensics, this is created on logon-->
+			<!--Windows shell hijack-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Classes\AllFilesystemObjects\</TargetObject> <!--Microsoft:Windows:Explorer: [ http://www.silentrunners.org/launchpoints.html ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Classes\*\</TargetObject> <!--Microsoft:Windows:Explorer: [ http://www.silentrunners.org/launchpoints.html ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Software\Microsoft\Ctf\LangBarAddin</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ContextMenuHandlers\</TargetObject> <!--Microsoft:Windows: [ http://oalabs.openanalysis.net/2015/06/04/malware-persistence-hkey_current_user-shell-extension-handlers/ ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\CurrentVersion\Shell</TargetObject> <!--Microsoft:Windows: Shell Folders, ShellExecuteHooks, ShellIconOverloadIdentifers, ShellServiceObjects, ShellServiceObjectDelayLoad [ http://oalabs.openanalysis.net/2015/06/04/malware-persistence-hkey_current_user-shell-extension-handlers/ ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\explorer\ShellIconOverlayIdentifiers</TargetObject> <!--Microsoft:Windows: ShellExecuteHooks-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Classes\Directory\</TargetObject> <!--Microsoft:Windows:Explorer: [ https://stackoverflow.com/questions/1323663/windows-shell-context-menu-option ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Classes\Drive\</TargetObject> <!--Microsoft:Windows:Explorer: [ https://stackoverflow.com/questions/1323663/windows-shell-context-menu-option ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\Software\Microsoft\Windows\CurrentVersion\explorer\ShellExecuteHooks</TargetObject> <!--Microsoft:Windows: ShellExecuteHooks -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Classes\Folder\</TargetObject> <!--Microsoft:Windows:Explorer: ContextMenuHandlers, DragDropHandlers, CopyHookHandlers, [ https://stackoverflow.com/questions/1323663/windows-shell-context-menu-option ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\Hidden</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\HideFileExt</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\SOFTWARE\Microsoft\Internet Explorer\Desktop\Components</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\SOFTWARE\Classes\Protocols\Filter</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\SOFTWARE\Classes\Protocols\Handler</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\SharedTaskScheduler</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\ShowSuperHidden</TargetObject> <!--Microsoft:Windows:Explorer: Some types of malware try to hide their hidden system files from the user, good signal event [ Example: https://www.symantec.com/security_response/writeup.jsp?docid=2007-061811-4341-99&tabid=2 ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ColumnHandlers</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\CopyHookHandlers</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ExtShellFolderViews</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\PropertySheetHandlers</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ShellServiceObjectDelayLoad</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ShellServiceObjects</TargetObject>
+			<!--AppPaths hijacking-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\</TargetObject> <!--Microsoft:Windows: Credit to @Hexacorn [ http://www.hexacorn.com/blog/2013/01/19/beyond-good-ol-run-key-part-3/ ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\AppCertDlls\</TargetObject> <!--Microsoft:Windows: Credit to @Hexacorn [ http://www.hexacorn.com/blog/2013/01/19/beyond-good-ol-run-key-part-3/ ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\System\CurrentControlSet\Control\Session Manager\S0InitialCommand</TargetObject> <!--Microsoft:Windows: Credit to @Hexacorn [ http://www.hexacorn.com/blog/2013/01/19/beyond-good-ol-run-key-part-3/ ] -->
+			<!--Terminal service boobytraps-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp\InitialProgram</TargetObject>
+			<!--Group Policy interity-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\GPExtensions\</TargetObject> <!--Microsoft:Windows: Group Policy internally uses a plugin architecture that nothing should be modifying-->
+			<!--Winsock and Winsock2-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\3\1809</TargetObject> <!--Microsoft:InternetExplorer: Malware sometimes disables Pop-up Blocker in Internet Zone [ https://support.microsoft.com/en-us/help/182569/internet-explorer-security-zones-registry-entries-for-advanced-users ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\3\2500</TargetObject> <!--Microsoft:InternetExplorer: Malware sometimes disables Protected Mode in Internet Zone [ https://blog.avast.com/2013/08/12/your-documents-are-corrupted-from-image-to-an-information-stealing-trojan/ ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\3\1206</TargetObject> <!--Microsoft:InternetExplorer: Malware sometimes assures scripting is on in Internet Zone [ https://support.microsoft.com/en-us/help/182569/internet-explorer-security-zones-registry-entries-for-advanced-users ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\DisableSecuritySettingsCheck</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\System\CurrentControlSet\Services\WinSock2\Parameters\NameSpace_Catalog5\Catalog_Entries64</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\System\CurrentControlSet\Services\WinSock2\Parameters\Protocol_Catalog9\Catalog_Entries64</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\System\CurrentControlSet\Services\WinSock2\Parameters\Protocol_Catalog9\Catalog_Entries</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Services\WinSock\</TargetObject> <!--Microsoft:Windows: Wildcard, includes Winsock and Winsock2-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\ProxyServer</TargetObject> <!--Microsoft:Windows: System and user proxy server-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">SavedLegacySettings</TargetObject>  <!--Microsoft:InternetExplorer: Wildcard for ProxyEnable, ProxyServer, ProxyOverride: Threats sometimes change proxy server -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Software\Microsoft\Windows\CurrentVersion\Internet Settings\Proxy</TargetObject>  <!--Microsoft:InternetExplorer: Wildcard for ProxyEnable, ProxyServer, ProxyOverride: Threats sometimes change proxy server -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">EnableConsoleTracing</TargetObject>  <!--Microsoft:InternetExplorer: Wildcard for ProxyEnable, ProxyServer, ProxyOverride: Threats sometimes change proxy server -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">EnableFileTracing</TargetObject>  <!--Microsoft:InternetExplorer: Wildcard for ProxyEnable, ProxyServer, ProxyOverride: Threats sometimes change proxy server -->
+			<!--Credential providers-->
+			<TargetObject name="Attack=T1177,Tactic=Execution/Persistence,Technique=LSASS Driver,Level=3,Alert=Detection of Modification of LSASS Protection" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Lsa\RunAsPPL</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\PLAP Providers</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\Credential Provider</TargetObject> <!--Wildcard, includes Credental Providers and Credential Provider Filters-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\Credential Provider Filters</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Lsa\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Netsh</TargetObject> <!-- [ https://attack.mitre.org/wiki/Technique/T1128 ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SecurityProviders\</TargetObject> <!--Microsoft:Windows: Changes to WDigest-UseLogonCredential for password scraping [ https://www.trustedsec.com/april-2015/dumping-wdigest-creds-with-meterpreter-mimikatzkiwi-in-windows-8-1/ ] -->
+			<!--Networking-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\NetworkProvider\Order\</TargetObject> <!--Microsoft:Windows: Order of network providers that are checked to connect to destination [ https://www.malwarearchaeology.com/cheat-sheets ] -->
+			<TargetObject name="Forensic=Monitor Network History" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\NetworkList\Profiles</TargetObject> <!--Microsoft:Windows: | Credit @ion-storm -->
+			<!--DLLs that get injected into every process launch-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Windows\Appinit_Dlls\</TargetObject> <!--Microsoft:Windows: [ https://msdn.microsoft.com/en-us/library/windows/desktop/dd744762(v=vs.85).aspx ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion\Windows\Appinit_Dlls\</TargetObject> <!--Microsoft:Windows: [ https://msdn.microsoft.com/en-us/library/windows/desktop/dn280412(v=vs.85).aspx ] -->
+			<!--Office-->
+			<!--Microsoft Office-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Office Test\</TargetObject> <!-- [ http://www.hexacorn.com/blog/2014/04/16/beyond-good-ol-run-key-part-10/ ] | Credit @Hexacorn -->
+			<!--Removed addins on 11/13/2018 due to high count-->
+			<!--IE-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Internet Explorer\Toolbar\</TargetObject> <!--Microsoft:InternetExplorer: Machine and user-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Internet Explorer\Extensions\</TargetObject> <!--Microsoft:InternetExplorer: Machine and user-->
+			<!--Magic registry keys-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Browser Helper Objects\</TargetObject> <!--Microsoft:InternetExplorer: Machine and user [ https://msdn.microsoft.com/en-us/library/bb250436(v=vs.85).aspx ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">{AB8902B4-09CA-4bb6-B78D-A8F59079A8D5}\</TargetObject> <!--Microsoft:Windows: Thumbnail cache autostart [ http://blog.trendmicro.com/trendlabs-security-intelligence/poweliks-levels-up-with-new-autostart-mechanism/ ] -->
+			<!--Infection artifacts-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\UrlUpdateInfo</TargetObject> <!--Microsoft:ClickOnce: [ https://subt0x10.blogspot.com/2016/12/mimikatz-delivery-via-clickonce-with.html ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\InstallSource</TargetObject> <!--Microsoft:Windows: Source folder for certain program and component installations-->
+			<!--Windows internals integrity monitoring-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\Drivers32</TargetObject> <!--Detect Legacy Driver loading-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\</TargetObject> <!--Microsoft:Windows:UAC: Detect malware changes to UAC prompt level -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\</TargetObject> <!--Microsoft:Defender: Detect changes to Defender administrative settings to monitor for disablement-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">TamperProtection</TargetObject> <!--Microsoft:Defender: Detect changes to Defender TamperProtection -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\</TargetObject> <!--Microsoft:Windows:UAC: Detect malware changes to UAC prompt level-->
+			<!--Group Policy Scripts-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Software\Microsoft\Windows\CurrentVersion\Group Policy\Scripts\Logoff</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Software\Policies\Microsoft\Windows\System\Scripts\Logoff</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Software\Microsoft\Windows\CurrentVersion\Group Policy\Scripts\Logon</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Software\Policies\Microsoft\Windows\System\Scripts\Logon</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Group Policy\State\Machine\Scripts\Shutdown</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Policies\Microsoft\Windows\System\Scripts\Shutdown</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Group Policy\State\Machine\Scripts\Startup</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Policies\Microsoft\Windows\System\Scripts\Startup</TargetObject>
+			<!--Detect Network History-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">Domain</TargetObject><!--Networking: Watch Domain Changes-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">DHCPDefaultGateway</TargetObject><!--Networking: Detect changes-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">DhcpIPAddress</TargetObject><!--Networking: Detect changes-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">DhcpNameserver</TargetObject><!--Networking: Detect changes-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">Dhcpserver</TargetObject><!--Networking: Detect changes-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">DhcpSubnetMask</TargetObject><!--Networking: Detect changes-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">Nameserver</TargetObject><!--Networking: Detect changes-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\DefaultGateway</TargetObject><!--Networking: Detect changes-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">PersistentRoutes</TargetObject><!--Networking: Detect persistent routes-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">}\Category</TargetObject><!--Networking: Detect Network type change-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\NetworkList\Profiles</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">SubnetMask</TargetObject><!--Networking: Detect changes-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Trusted Documents\TrustRecords</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Software\Microsoft\VBA\7.1\Common</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Software\Microsoft\VBA\7.1\Trusted</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Security\DontTrustInstalledFiles</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Security\Trusted Locations</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">Security\ProtectedView\DisableInternetFilesInPV</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">Security\ProtectedView\DisableAttachmentsInPV</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">Security\ProtectedView\DisableUnsafeLocationsInPV</TargetObject>
+			<TargetObject name="Forensic=WinRAR History" condition="contains">Software\WinRAR\ArcHistory</TargetObject>
+			<TargetObject name="Forensic=Winzip History" condition="contains">WinZip\mru\</TargetObject>
+			<TargetObject name="Forensic=Misc Recent File List History" condition="contains">Recent File List</TargetObject>
+			<TargetObject name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=3,Alert=Office Homepage Attack,Risk=70" condition="contains">Outlook\WebView\Inbox</TargetObject>
+			<TargetObject name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=3,Alert=Office Homepage Attack,Risk=70" condition="contains">Outlook\Today\UserDefinedUrl</TargetObject>
+			<TargetObject name="Attack=T1203,Technique=Exploitation for Client Execution,Tactic=Execution,Level=3,Alert=Office Calendar Homepage Attack,Risk=70" condition="contains">Outlook\WebView\Calendar</TargetObject>
+			<TargetObject name="Forensic=Office History" condition="contains">\Place MRU</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\LinkDate</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\DriverVerVersion</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\DriverVersion</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\LowerCaseLongPath</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\Publisher</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Compatibility Assistant\Store\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\BinProductVersion</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Root\InventoryApplicationShortcut\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Root\InventoryDriverBinary\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Root\InventoryDeviceContainer\</TargetObject>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">Root\InventoryApplication\</TargetObject>
+				<TargetObject condition="contains any">ProgramID;Name;Version;Publisher;Language;InstallDate;Source;RootDirPath;HiddenArp;UninstallString;RegistryKeyPath;UserSID;sha256</TargetObject>
+			</Rule>			
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">Root\InventoryApplicationFile\</TargetObject>
+				<TargetObject condition="contains any">ProgramId;FileId;LowerCaseLongPath;Name;OriginalFileName;Publisher;Version;binfileversion;LinkDate;Size;Language;USN;IsPeFile;IsOsComponent;sha256;AppxPackageFullName</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains">Root\InventoryApplicationAppV\</TargetObject>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetObject condition="contains any">Root\InventoryMiscellaneousOfficeAddIn;Root\InventoryMiscellaneousOfficeIdentifiers;Root\InventoryMiscellaneousOfficeIESettings;Root\InventoryMiscellaneousOfficeInsights;Root\InventoryMiscellaneousOfficeProducts;Root\InventoryMiscellaneousOfficeSettings;Root\InventoryMiscellaneousOfficeVBA;Root\InventoryMiscellaneousOfficeVBARuleViolations</TargetObject>
+			</Rule>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\Explorer\MountPoints2</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices</TargetObject>
+			<Rule name="Attack=T1489,Technique=Service Stop,Tactic=Impact,Level=1,Desc=Service Set for Deletion" groupRelation="and">
+				<TargetObject condition="contains">HKLM\System\CurrentControlSet\services\</TargetObject>
+				<TargetObject condition="end with">\DeleteFlag</TargetObject>
+				<Details condition="contains">DWORD (0x00000001)</Details>
+			</Rule>
+			<!--Detect User Activity-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ConsentStore\bluetooth</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ConsentStore\contacts</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ConsentStore\hunmanInterfaceDevice</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ConsentStore\location</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ConsentStore\microphone</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ConsentStore\usb\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ConsentStore\webcam</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\ConsentStore\humanInterfaceDevice</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">LastVisitedMRU</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">SOFTWARE\Microsoft\Windows\CurrentVersion\Applets\RegEdit</TargetObject>
+			<TargetObject name="Forensic=Run MRU" condition="contains">\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Enum\USBSTOR</TargetObject>
+			<TargetObject name="Attack=T1112,Technique=Modify Registry,Tactic=Defense Evasion,Level=4,Alert=Safeboot Service Added" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Safeboot\</TargetObject> <!--Microsoft:Windows: Services approved to load in safe mode-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Cryptography\Providers\Trust</TargetObject><!--Mitre T1198-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\WOW6432Node\Microsoft\Cryptography\Providers\Trust</TargetObject><!--Mitre T1198-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Cryptography\OID</TargetObject> <!--Mitre T1198-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\WOW6432Node\Microsoft\Cryptography\OID</TargetObject><!--Mitre T1198-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Services\DNS\Parameters\ServerLevelPluginDll</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Classes\exefile\shell\runas\command\isolatedCommand</TargetObject> 
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\FriendlyName</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Winlogon\</TargetObject> <!--Microsoft:Windows: Providers notified by WinLogon-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\Software\Microsoft\Windows\CurrentVersion\Internet Settings\AutoConfigURL</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\ShellServiceObjectDelayLoad</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\InProgress\(Default)</TargetObject>
+			<!--Windows application compatibility shims-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Custom</TargetObject> <!--Microsoft:Windows: AppCompat [ https://www.fireeye.com/blog/threat-research/2017/05/fin7-shim-databases-persistence.html ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\InstalledSDB</TargetObject> <!--Microsoft:Windows: AppCompat [ https://www.fireeye.com/blog/threat-research/2017/05/fin7-shim-databases-persistence.html ] -->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Microsoft\Tracing\</TargetObject> <!--Microsoft:Windows: Malware sometimes disables tracing to obfuscate tracks-->
+			<!-- NOTICE: Detect New USB Network Devices: Poison Tap: Creates lots of noise, disabled for now-->
+			<Rule name="Alert=Detect PoisonTap,FP=2,Comment=May be noisy" groupRelation="and">
+				<TargetObject condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Class\{4d36e972-e325-11ce-bfc1-08002be10318}</TargetObject>
+				<Details condition="contains any">ndis;rndis</Details>
+			</Rule>
+			<TargetObject name="Attack=T1090,Technique=Connection Proxy,Tactic=Defense Evasion,Level=0,Desc=NetSH PortProxy Detected" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Services\PortProxy\v4tov4</TargetObject>
+			<Rule name="Attack=T1112,Technique=Modify Registry,Tactic=Defense Evasion,Alert=Possible Ursniff Malware Detected,FP=1" groupRelation="and">
+				<TargetObject condition="contains">\Software\AppDataLow\Software\Microsoft\</TargetObject>
+				<Details condition="contains any">.exe;.dll;powershell;wmic</Details>
+			</Rule>
+			<TargetObject name="Attack=T1137,Technique=Office Application Startup,Tactic=Persistence,Level=4,Alert=Office Persistence Location,Risk=70" condition="end with">Software\Microsoft\Office test\Special\Perf</TargetObject>
+			<TargetObject name="Attack=T1177,Technique=LSASS Driver,Tactic=Execution/Persistence,Level=0,Desc=Undocumented LSASS DLL Loading" condition="contains">\CurrentControlSet\Services\NTDS\LsaDbExtPt</TargetObject>
+			<TargetObject name="Attack=T1177,Technique=LSASS Driver,Tactic=Execution/Persistence,Level=0,Desc=Undocumented LSASS DLL Loading" condition="contains">\Services\NTDS\DirectoryServiceExtPt</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Forensic=GoToMyPC File Transfer History,Risk=70" condition="contains">GoToMyPc\FileTransfer\history</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Forensic=GoToMyPC Guest Invite,Risk=70" condition="contains">GoToMyPc\GuestInvite</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Forensic=LogMeIn File Transfer Recipient" condition="contains">Filesharing</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Forensic=LogMeIn Guest Recipient" condition="contains">DesktopSharing</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Forensic=Teamviewer LogIncomingConnections Registry Key modification" condition="contains">LogIncomingConnections</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Forensic=Teamviewer LogOutgoingConnection Registry Key modification" condition="contains">LogOutgoingConnections</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Forensic=Teamviewer Password Registry Key date" condition="contains">PermanentPasswordDate</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Level=4,Alert=Teamviewer adminrights Key modification,Risk=70" condition="contains">Security_Adminrights</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Level=3,Alert=VNC Incoming Connection History,Risk=70" condition="contains">vncviewer\MRU</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Level=0,Desc=Teamviewer Autostart Key modification" condition="contains">Autostart_GUI</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Level=0,Desc=Teamviewer Meeting Username Registry Key modification" condition="end with">Meeting_UserName</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Level=0,Desc=Teamviewer Persistence Login Name" condition="end with">BuddyLoginName</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Level=0,Desc=Teamviewer Persistence Token ID modification" condition="end with">BuddyLoginTokenID</TargetObject>
+			<TargetObject name="Attack=T1219,Technique=Remote Access Tools,Tactic=Command And Control,Level=0,Desc=Teamviewer persistence Key modification" condition="contains">Always_Online</TargetObject>
+			<TargetObject name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=Potential Ransomware Indicator: EnableLinkedConnections Registry key,Risk=100" condition="begin with">HKLM\SOFTWARE\Microsoft\CurrentVersion\Policies\System\EnableLinkedConnections</TargetObject>
+			<TargetObject name="Attack=T1486,Technique=Data Encrypted for Impact,Tactic=Impact,Level=4,Alert=Potential Ransomware Indicator: REvil Sodinokibi Sodin Ransomware,Risk=100" condition="contains">Software\recfg</TargetObject>
+			<TargetObject name="Attack=T0000,Technique=Keyboard Layout,Tactic=N/A,Level=0,Desc=Suspicious Keyboard Layout Load" condition="contains">\Keyboard Layout\Preload\</TargetObject>
+			<TargetObject name="Attack=T0000,Technique=Keyboard Layout,Tactic=N/A,Level=0,Desc=Suspicious Keyboard Layout Load" condition="contains">\Keyboard Layout\Substitutes\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SOFTWARE\Policies\Microsoft\Cryptography\Configuration\SSL\00010002</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Hashes\</TargetObject> 
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\KeyExchangeAlgorithms\Diffie-Hellman</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\Client\Enabled</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">\Server\Enabled</TargetObject>
+			<TargetObject name="Forensic=Kitty Sessions,Risk=30" condition="contains">Kitty\Sessions</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Lsa\NtlmMinClientSec</TargetObject> <!--Detects post exploitation using NetNTLM downgrade attacks-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Lsa\RestrictSendingNTLMTraffic</TargetObject> <!--Detects post exploitation using NetNTLM downgrade attacks-->
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">HKLM\SYSTEM\CurrentControlSet\Control\Lsa\lmcompatibilitylevel</TargetObject> <!--Detects post exploitation using NetNTLM downgrade attacks-->
+			<TargetObject name="Forensic=Putty Sessions,Risk=30" condition="contains">PuTTY\Sessions</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Terminal Server Client\Servers</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">WinSCP 2\Sessions</TargetObject>
+			<TargetObject name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">WinSCP 2\Sessions</TargetObject>
+		</RegistryEvent>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 15 : ALTERNATE DATA STREAM CREATED [FileCreateStreamHash]-->
+	<!--EVENT 15: "File stream created"-->
+	<RuleGroup name="RG=ADS Include Group" groupRelation="or">
+		<FileCreateStreamHash onmatch="include">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="contains any">Content.IE5;INetCache</TargetFilename>
+				<TargetFilename condition="contains any">.exe;.zip;.ps1;.bat;.rar;.vbs;.hta</TargetFilename>
+			</Rule>
+			<Rule name="Level=4,Alert=HTML_Smuggling,Risk=50" groupRelation="and">
+				<TargetFilename condition="end with">:Zone.Identifier</TargetFilename>
+				<Contents condition="contains any">blob:;about:internet</Contents>
+			</Rule>
+			<Rule name="Attack=T1195,Technique=Supply Chain Compromise,Tactic=Initial Access,Level=4,Alert=FireEye sunburst file hashes,Risk=100" groupRelation="and">
+				<Hash condition="contains any">56ceb6d0011d87b6e4d7023d7ef85676;4f2eb62fa529c0283b28d05ddd311fae;b91ce2fa41029f6955bff20079468448;b91ce2fa41029f6955bff20079468448;846e27a652a5e1bfbd0ddd38a16dc865;2c4a910a1299cdae2a4e55988a2f102e</Hash><!-- exclude non executable files -->
+			</Rule>
+			<Rule name="Attack=T1096,Technique=Alternate Data Streams,Tactic=Defense Evasion,Level=0,Desc=Alternate Data Streams,Risk=10" groupRelation="and">
+				<TargetFilename condition="contains any">Content.Outlook;Downloads;Recycle;\Users\;\ProgramData\;\Windows\;Temp\7z;Temp\;Startup;.vb;.vbe;.vbs;.application;.appref-ms;.bat;.cmd;.cmdline;.docm;.exe;.lnk;.eml;.dll;.sys;.hta;.pptm;.ps1;.sys;.reg;.docm;.xlsm;.xlam;.pptm;.potm;.pptm;.sldm;.scf;.appref-ms;.rdp;.vbs;.js;.pem;.crt;.ca-bundle;.cer;.csr;.der;.p7b;.p7r;.p7s;.pfx;.sto;.p12;.crl;.sst;.key;:bin;.mht;.manifest;.cpl;.scr;.inf</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1562.002,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=SysmonEnte Detection,Level=4,Risk=100" groupRelation="and">
+				<Hash condition="contains">IMPHASH=84B763C45C0E4A3E7CA5548C710DB4EE</Hash>
+			</Rule>
+			<Rule name="Attack=T1562.002,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=SysmonQuiet Detection,Level=4,Risk=100" groupRelation="and">
+				<Hash condition="contains">IMPHASH=19584675D94829987952432E018D5056</Hash>
+			</Rule>
+			<Rule name="Attack=T1562.002,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=SharpEvtMute Detection,Level=4,Risk=100" groupRelation="and">
+				<Hash condition="contains">IMPHASH=330768a4f172e10acb6287b87289d83b</Hash>
+			</Rule>
+		</FileCreateStreamHash>
+	</RuleGroup>
+	<RuleGroup name="RG=ADS Exclude Group" groupRelation="or">
+		<FileCreateStreamHash onmatch="exclude">
+			<Hash condition="contains">IMPHASH=00000000000000000000000000000000</Hash>
+			<TargetFilename condition="contains">AppData\Local\Microsoft\Windows\AppCache\</TargetFilename>
+			<TargetFilename condition="contains">\Microsoft\Windows\INetCache\</TargetFilename>
+			<TargetFilename condition="contains">\Microsoft\Windows\Temporary Internet Files\Content.IE5</TargetFilename> 
+			<TargetFilename condition="contains">\Mozilla\Firefox\Profiles\</TargetFilename>
+			<TargetFilename condition="end with">.default\prefs-1.js</TargetFilename>
+			<TargetFilename condition="end with">Microsoft\Windows\Start Menu\Programs\Startup</TargetFilename>
+		</FileCreateStreamHash>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 16 : SYSMON CONFIGURATION CHANGE-->
+	<!--EVENT 16: "Sysmon config state changed"-->
+	<!--COMMENT:	This ONLY logs if the hash of the configuration changes. Running "sysmon.exe -c" with the current configuration will not be logged with Event 16-->
+	<!--DATA: RuleName, UtcTime, Configuration, ConfigurationFileHash-->
+	<!--Cannot be filtered.-->
+
+	<!--SYSMON EVENT ID 17 & 18 : PIPE CREATED / PIPE CONNECTED [PipeEvent]-->
+	<!--EVENT 17: "Pipe Created"-->
+	<!--EVENT 18: "Pipe Connected"-->
+	<!--DATA: RuleName, UtcTime, ProcessGuid, ProcessId, PipeName, Image-->
+	<RuleGroup name="RG=PipeEvent Include Group" groupRelation="or">
+		<PipeEvent onmatch="include">
+			<Rule name="Attack=T1071,Technique=Application Layer Protocol,Tactic=Command and Control,Level=4,Alert=Cobalt Strike named pipe detected,Risk=100" groupRelation="and">
+				<PipeName condition="contains any">msagent_;\MSSE-;postex;\status_</PipeName>
+			</Rule>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=NA,Level=4,Alert=Turla Advanced Persistent Threat Named Pipe Detection,Risk=100" groupRelation="and">
+				<PipeName condition="contains any">\atctl;\userpipe;\iehelper;\sdlrpc;\comnap</PipeName>
+			</Rule>
+			<Rule name="Attack=T1077,Technique=Windows Admin Shares,Tactic=Lateral Movement,Level=4,Alert=lateral movement: psexec named pipe detected" groupRelation="or">
+				<PipeName condition="contains">\PSEXESVC</PipeName>
+				<PipeName condition="end with">-stdin</PipeName>
+				<PipeName condition="end with">-stdout</PipeName>
+			</Rule>
+			<Rule name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=MS-SCMR Execution" groupRelation="or">
+				<PipeName condition="contains">\svcctl</PipeName>
+			</Rule>
+			<Rule name="Attack=T1021,Technique=Remote Services,Tactic=Lateral Movement,Level=3,Alert=NTSVCS Execution" groupRelation="or">
+				<PipeName condition="contains">\ntsvcs</PipeName>
+			</Rule>
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=9f81f59bc58452127884ce513865ed20 Named Pipe Detection,Risk=100" condition="contains">\9f81f59bc58452127884ce513865ed20</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=46a676ab7f179e511e30dd2dc41bd388 Named Pipe Detection,Risk=100" condition="contains">\46a676ab7f179e511e30dd2dc41bd388</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=Kekeo Named Pipe Detection,Risk=100" condition="contains">tssmp_endpoint</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=NamePipe_MoreWindows Named Pipe Detection,Risk=100,Risk=100" condition="contains">\NamePipe_MoreWindows</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=WCEServicePipe detected,Risk=100" condition="contains">\WCEServicePipe</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=ahexec Named Pipe Detection,Risk=100" condition="contains">\ahexec</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=cachedump detected,Risk=100" condition="contains">\cachedumppipe</PipeName><!-- Credits @9f81f59bc58452127884ce513865ed20Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=csexec Named Pipe Detection,Risk=100" condition="contains">\csexec</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=e710f28d59aa529d6792ca6ff0ca1b34 Named Pipe Detection,Risk=100" condition="contains">\e710f28d59aa529d6792ca6ff0ca1b34</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=isapi_dg2 Named Pipe Detection,Risk=100" condition="contains">\isapi_dg</PipeName><!-- Credits @Cyb3rops & @olafhartong-->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=isapi_http Named Pipe Detection,Risk=100" condition="contains">\isapi_http</PipeName><!-- Credits @Cyb3rops & @olafhartong-->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=isapi_http Named Pipe Detection,Risk=100" condition="contains">\isapi_http</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=lsadump detected,Risk=100" condition="contains">\lsadump</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=lsassw Named Pipe Detectio,Risk=10" condition="contains">\lsassw</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=paexec Named Pipe Detection,Risk=100" condition="contains">\paexec</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=pcheap_reuse Named Pipe Detection" condition="contains">\pcheap_reuse</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=Covanant C2 Named Pipe Detection" condition="contains">\gruntsvc</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=remcom Named Pipe Detection,Risk=100" condition="contains">\remcom</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=rpchlp_3 Named Pipe Detection,Risk=100" condition="contains">\rpchlp_3</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=sdlrpc Named Pipe Detection,Risk=100" condition="contains">\sdlrpc</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=winsession Named Pipe Detection,Risk=100" condition="contains">\winsession</PipeName><!-- Credits @Cyb3rops & @olafhartong -->
+			<PipeName name="Attack=T1077,Technique=Windows Admin Shares,Tactic=Lateral Movement,Alert=lateral movement -meterpreter named pipe detected,Risk=100" condition="contains">msf-pipe</PipeName>
+			<PipeName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\atsvc</PipeName> <!-- useful for lm or exec over atsvc namedpipe -->
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=Malicious Named Pipe Detection 1" condition="contains any">\isapi_http;\isapi_dg;\isapi_dg2;\sdlrpc;\ahexec;\winsession;\lsassw;\46a676ab7f179e511e30dd2dc41bd388;\9f81f59bc58452127884ce513865ed20;\e710f28d59aa529d6792ca6ff0ca1b34;\rpchlp_3;\NamePipe_MoreWindows;\pcheap_reuse;\gruntsvc;\583da945-62af-10e8-4902-a8f205c72b2e;\bizkaz;\Posh;\jaccdpqnvbrrxlaf;\csexecsvc</PipeName>
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=Malicious Named Pipe Detection 2" condition="contains any">\atctl;\userpipe;\iehelper;\sdlrpc;\comnap</PipeName>
+			<PipeName name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=Malicious Named Pipe Detection 2" condition="contains any">\DserNamedPipe;\mypipe-;\windows.update.manager;\ntsvcs_;scerpc_;\demoagent;\PGMessagePipe;\MsFTeWds;\f4c3;\fullduplex_;\msrpc_;\f53f;\rpc_;\spoolss_;\win_svc;\SearchTextHarvester</PipeName>
+			<Rule name="Attack=T1055,Technique=Process Injection,Tactic=Defense Evasion/Privilege Escalation,Level=4,Alert=EFSPotato Named Pipe Detection" groupRelation="and">
+				<PipeName condition="contains any">\pipe\</PipeName>
+				<PipeName condition="excludes">CtxSharefilepipe0</PipeName>
+			</Rule>
+			<!-- Noisy
+			<PipeName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\srvsvc</PipeName>
+			-->
+			<PipeName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\winreg</PipeName> <!-- useful for lateral movement and users enumeration, psloggedon use this technique -->
+			<PipeName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Anonymous Pipe</PipeName><!--Include Everything else to mark above rules-->
+			<!--Include Everything else to mark above rules-->
+			<!-- Disabled for now
+			<PipeName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\</PipeName>
+			-->
+		</PipeEvent>
+	</RuleGroup>
+	<RuleGroup name="RG=PipeEvent Exclude Group" groupRelation="or">
+		<PipeEvent onmatch="exclude">
+		<EventType name="Exclude ConnectPipe for noise reduction" condition="is">ConnectPipe</EventType>
+		<!--COMMENT: Exclude known-good pipe users-->
+				<!--ADDITIONAL REFERENCE: [ https://www.cobaltstrike.com/help-smb-beacon ] -->
+				<!--ADDITIONAL REFERENCE: [ https://blog.cobaltstrike.com/2015/10/07/named-pipe-pivoting/ ] -->
+			<!--SECTION: Microsoft-->
+			<PipeName condition="contains">lsass</PipeName>
+			<PipeName condition="is">\SQLLocal\RTCLOCAL</PipeName>
+			<PipeName condition="is">\spoolss</PipeName>
+			<Image condition="image">C:\Windows\system32\wbem\wmiprvse.exe</Image> <!-- Rediculous amount of spam, likely spikes cpu if logged -->
+			<Image condition="image">C:\Windows\System32\LxRun.exe</Image> <!--WSL-->
+			<Image condition="image">C:\Windows\System32\SearchIndexer.exe</Image>
+			<Image condition="image">C:\Windows\System32\smss.exe</Image>
+			<Image condition="image">C:\Windows\System32\spoolsv.exe</Image>
+			<Image condition="image">C:\Windows\System32\wininit.exe</Image>
+			<Image condition="image">C:\Windows\system32\DFSRs.exe</Image>
+			<Image condition="begin with">C:\Windows\SystemApps\Microsoft.Windows</Image>
+			<Rule name="ngen excludes" groupRelation="and">
+				<Image condition="begin with">C:\Windows\Microsoft.NET\Framework</Image>
+				<Image condition="end with">\ngen.exe</Image>
+			</Rule>
+			<Rule name="ShellExperienceHost excludes" groupRelation="and">
+				<Image condition="begin with">C:\Windows\SystemApps\ShellExperienceHost_</Image>
+				<Image condition="end with">\ShellExperienceHost.exe</Image>
+			</Rule>
+			<Image condition="image">C:\Windows\system32\SearchProtocolHost.exe</Image>
+			<Image condition="image">\System</Image>
+			<PipeName condition="contains">ProtectedPrefix\LocalService\FTHPIPE</PipeName>
+			<!--SECTION: Microsoft Exchange Server -->
+			<Image condition="contains">Exchange Server</Image>
+			<!--SECTION: Microsoft IIS -->
+			<Image condition="image">C:\Program Files\Common Files\Microsoft Shared\Web Server Extensions\15\BIN\OWSTIMER.EXE</Image>
+			<Image condition="image">C:\Windows\syswow64\snmp.exe</Image>
+			<Image condition="image">c:\windows\system32\inetsrv\w3wp.exe</Image>
+			<PipeName condition="begin with">\M.E.C.Core.WinRMDataCommunicator.NamedPipe.</PipeName>
+			<!--SECTION: Microsoft DNS Server -->
+			<Image condition="image">C:\Windows\system32\dns.exe</Image>
+			<!--SECTION: Microsoft SQL Server -->
+			<PipeName condition="is">\sql\query</PipeName>
+			<Image condition="image">C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe</Image>
+			<PipeName condition="contains">\TDLN-</PipeName>
+			<PipeName condition="contains">vmware-</PipeName>
+			<PipeName condition="is">\InitShutdown</PipeName>
+			<PipeName condition="is">\MsFteWds</PipeName>
+			<PipeName condition="is">\W32TIME_ALT</PipeName>
+			<PipeName condition="is">\WiFiNetworkManagerTask</PipeName>
+			<PipeName condition="is">\Winsock2CatelogChangeListener</PipeName>
+			<PipeName condition="is">\browser</PipeName>
+			<PipeName condition="is">\epmapper</PipeName>
+			<PipeName condition="is">\eventlog</PipeName>
+			<PipeName condition="is">\scerpc</PipeName>
+			<PipeName condition="is">\wkssvc</PipeName>
+			<PipeName condition="is">\ntapvsrq</PipeName>
+			<PipeName condition="contains">Anonymous Pipe</PipeName>
+		</PipeEvent>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 19 & 20 & 21 : WMI EVENT MONITORING [WmiEvent]-->
+	<!--EVENT 19: "WmiEventFilter activity detected"-->
+	<!--EVENT 20: "WmiEventConsumer activity detected"-->
+	<!--EVENT 21: "WmiEventConsumerToFilter activity detected"-->
+	<!--DATA: EventType, UtcTime, Operation, User, Name, Type, Destination, Consumer, Filter-->
+	<RuleGroup name="RG=WmiEvent Include Group" groupRelation="or">
+		<WmiEvent onmatch="include">
+			<Operation name="Attack=T1047,Technique=Windows Management Instrumentation,Tactic=Execution" condition="is">Created</Operation>
+		</WmiEvent>
+	</RuleGroup>
+	<!-- SYSMON EVENT ID 22 : DNS Queries-->
+	<RuleGroup name="RG=DNS Query Includes" groupRelation="or">
+		<DnsQuery onmatch="include">
+			<Rule name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=0,Desc=Powershell TXT Record exfiltration" groupRelation="and">
+				<QueryResults condition="contains any">type: 16;type:  16</QueryResults>
+				<Image condition="image">powershell.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1059,Technique=Powershell,Tactic=Execution,Level=4,Alert=Powershell Connection to github" groupRelation="and">
+				<QueryName condition="contains">github</QueryName>
+				<Image condition="image">powershell.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">powershell;cscript.exe;wscript.exe;mshta.exe;bitsadmin.exe;\cmd.exe</Image>
+				<QueryName condition="contains">.</QueryName>
+			</Rule>
+			<Rule name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=0,Desc=Dropbox Cloud Exfiltration" groupRelation="and">
+				<QueryName condition="end with">dropboxapi.com</QueryName>
+				<Image condition="excludes any">\Dropbox\Client\Dropbox.exe;\Dropbox\bin\Dropbox.exe;\Oracle\Java\</Image>
+			</Rule>
+			<Rule name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=0,Desc=OneDrive Cloud Exfiltration" groupRelation="and">
+				<QueryName condition="contains">1drv</QueryName>
+				<Image condition="excludes any">\AppData\Local\Microsoft\OneDrive\OneDrive.exe;C:\Program Files (x86)\Google\Chrome\Application\chrome.exe;\Internet Explorer\iexplore.exe;C:\Windows\System32\AppHostRegistrationVerifier.exe;C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe;C:\Program Files (x86)\BraveSoftware\Brave-Browser\Application\brave.exe;C:\Program Files (x86)\Microsoft OneDrive\OneDrive.exe;C:\Program Files\Mozilla Firefox\firefox.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=0,Desc=Box.com Cloud Exfiltration" groupRelation="and">
+				<QueryName condition="contains all">.box.com;upload</QueryName>
+			</Rule>
+			<Rule name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=4,Alert=Mega.co.nz Cloud Exfiltration" groupRelation="and">
+				<QueryName condition="contains any">mega.nz;mega.co.nz</QueryName>
+			</Rule>
+			<Rule name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=4,Alert=Privatlab Cloud Exfiltration" groupRelation="and">
+				<QueryName condition="contains any">privatlab.com</QueryName>
+			</Rule>
+			<Rule name="Attack=T1195,Technique=Supply Chain Compromise,Tactic=Initial Access,Level=4,Alert=Solarwinds/FireEye sunburst domains,Risk=100" groupRelation="or">
+				<QueryName condition="contains any">thedoccloud.com;deftsecurity.com;websitetheme.com;highdatabase.com;incomeupdate.com;zupertech.com;panhardware.com;databasegalore.com;avsvmcloud.com;freescanonline.com</QueryName>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="or">
+				<QueryName condition="contains any">tiktok;parler.com;gab.com;mewe.com;4chan;8chan;facebook;fbcdn;twitter;instagram;snapchat</QueryName>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="or">
+				<QueryName condition="contains any">efnet;undernet;freenode;ircnet;.rizon;quakenet;oftc.net;dalnet</QueryName>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<QueryName condition="contains any">.slack.com;discord.;telegram.;rocketchat.;mattermost.;flock.com</QueryName>
+			</Rule>
+			<!--Crypto Currency Mining pools-->
+			<Rule name="Level=4,Alert=Crypto Currency Miner Detected,Attack=T1496,Technique=Resource Hijacking,Tactic=Impact,Risk=10"  groupRelation="or">
+				<QueryName condition="contains any">0x1f4b0.com;1q2w3.life;1q2w3.website;31.187.64.216;185.193.38.148;aalbbh84.info;adfreetv.ch;adless.io;adplusplus.fr;adrenali.gq;ajcryptominer.com;ajplugins.com;allfontshere.press;altavista.ovh;amhixwqagiz.ru;appelamule.com;arizona-miner.tk;aster18cdn.nl;aster18prx.nl;avero.xyz;averoconnector.com;bauersagtnein.myeffect.net;bhzejltg.info;blazepool;blockmasters;blockmasterscoins;bmnr.pw;bmst.pw;bohemianpool;carry.myeffect.net;cashbeet.com;cdn-code.host;cfceu.duckdns.org;cfcnet.gdn;cfcnet.top;cfcs1.duckdns.org;chainblock.science;cieh.mx;coin-hive.com;coin-service.com;coin-services.info;coiner.site;coinpirate.cf;coinrail.io;coinwebmining.com;cpu2cash.link;cryptaloot.pro;cryptmonero;crypto-loot.com;crypto-pool;crypto-webminer.com;cryptoloot.pro;d-ns.ga;dataservices.download;directprimal.com;dwarfpool;encoding.ovh;eth-pocket.com;eth-pocket.de;eth-pocket.eu;ethereum-pocket.de;ethereum-pocket.eu;ethtrader.de;eu.nimpool.io;eu.sushipool.com;f1tbit.com;flnqmin.org;freecontent.bid;freecontent.date;freecontent.loan;freecontent.racing;freecontent.stream;freecontent.win;gnrdomimplementation.com;graftpool.ovh;greenindex.dynamic-dns.net;gustaver.ddns.net;hashrefinery;hashvault.pro;herphemiste.com;hide.ovh;hk.rs;hlpidkr.ru;hodlers.party;hodling.faith;hostingcloud.win;hrfziiddxa.ru;ihdvilappuxpgiv.ru;imhvlhaelvvbrq.ru;insdrbot.com;irrrymucwxjl.ru;istlandoll.com;ivuovhsn.ru;iwanttoearn.money;ixvenhgwukn.ru;jqassets.download;jqr-cdn.download;jqrcdn.download;jquerrycdn.download;jqwww.download;jqxrrygqnagn.ru;jscoinminer.com;jwduahujge.ru;ksimdw.ru;l33tsite.info;laferia.cr;ledhenone.com;ltstyov.ru;mepirtedic.com;mine.bz;minercircle.com;minercry.pt;minergate;minero.cc;miners.pro;minescripts.info;mininghub.club;miningpoolhubcoins;minr.pw;mixpools.org;mmc.center;mollnia.com;monerise.com;monero.lindon-pool.win;monero;moriaxmr.com;munero.me;mxcdn1.now.sh;mxcdn2.now.sh;myadstats.com;mypool.online;nablabee.com;nanopool.org;nathetsof.com;nicehash;nimiqpool.com;node.philpool.com;npcdn1.now.sh;nunu-001.now.sh;ogondkskyahxa.ru;ogrid.org;oinkinns.tk;olecintri.com;omine.org;onvid.club;open-hive-server-1.pp.ua;oxwwoeukjispema.ru;pcejuyhjucmkiny.ru;pool.nimiq.watch;pool.nimiqchain.info;pool.porkypool.com;pool.xmr;poolto.be;prohash.net;prohash;proj2018.xyz;pzoifaum.info;ratchetmining.com;realnetwrk.com;reauthenticator.com;rove.cl;ruvuryua.ru;s7ven.com;scaleway.ovh;sentemanactri.com;sickrage.ca/ch;sighash.info;slushpool;soodatmish.com;sparechange.io;statdynamic.com;stati.bid;staticsfs.host;streamplay.to;suprnova.cc;svivqrhrh.ru;sxcdn02.now.sh;sxcdn3.now.sh;sxcdn4.now.sh;sxcdn6.now.sh;synconnector.com;teracycle.net;tercabilis.info;thelifeisbinary.ddns.net;thersprens.com;torrent.pw;ulnawoyyzbljc.ru;unrummaged.com;uoldid.ru;usxmrpool;viaxmr.com;vpzccwpyilvoyg.ru;vzzexalcirfgrf.ru;wbmwss.beetv.net;webmine.cz;webmine.pro;webminepool.tk;webminerpool.com;webwidgetz.duckdns.org;wmemsnhgldd.ru;wmtech.website;wmwmwwfmkvucbln.ru;wrxgandsfcz.ru;xmrm.pw;xmrminingproxy.com;xmrpool;yiimp;yuyyio.com;zavzlen.ru;zergpool;zergpoolcoins;ziykrgc.ru;zlx.com.br;zpool;analytics.blue;estream.to</QueryName>
+			</Rule>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">graph.microsoft.com</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">dl.dropboxusercontent.com</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="is">api.onedrive.com</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">zoom.us</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">teamviewer</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">Screenconnect</QueryName>
+			<!--Public Port Scan Detection-->
+			<!--MITRE ATT&CK TECHNIQUE: Active Scanning-->
+			<QueryName name="Attack=T1595,Technique=Active Scanning,Tactic=Discovery" condition="contains">census</QueryName>
+			<QueryName name="Attack=T1595,Technique=Active Scanning,Tactic=Discovery,Level=0,Desc=ResearchScan DNS Query" condition="contains">researchscan</QueryName>
+			<QueryName name="Attack=T1595,Technique=Active Scanning,Tactic=Discovery,Level=0,Desc=ScanHub DNS Query" condition="contains">scanhub</QueryName>
+			<QueryName name="Attack=T1595,Technique=Active Scanning,Tactic=Discovery,Level=0,Desc=Shadow DNS Query,Risk=20" condition="contains">shadow</QueryName>
+			<QueryName name="Attack=T1595,Technique=Active Scanning,Tactic=Discovery,Level=0,Desc=Shodan.IO DNS Query,Risk=20" condition="contains">shodan</QueryName>
+			<!--Domain TLD's to log-->
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.download</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.kp</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.su</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.ss</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xn</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.sy</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.ve</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xxx</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.cn</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.click</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.club</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.ir</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.ru</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.host</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.icu</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.pw</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.website</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.ninja</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.rocks</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.top</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.ua</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="end with">.xyz</QueryName>
+			<!--Malware Domains-->
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<QueryName condition="contains any">kuternull.com;rimrun.com;0ffice36o;asushotfix;infestexe;rahasn.webhop.org;rahasn.akamake.net;rahasn.homewealth.biz;winodwsupdates;israirairlines</QueryName>
+			</Rule>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains any">githubusercontent.com;github.com</QueryName> 
+			<!--Common Suspicious destinations-->
+			<QueryName name="Attack=T1311,Technique=Dynamic DNS,Tactic=Adversary Opsec,Level=0,Desc=Malware IP Check,Risk=30" condition="contains any">api.ipify.org;whatismyipaddress.com;edns.ip-api.com;checkip.dyndns.org;icanhazip.com;ifconfig.me;ifconfig.co;ipaddress.com;ipecho.net;ident.me;api.ip.sb;www.myexternalip.com;ip.anysrc.net;wtfismyip.com;myexternalip.com;ipecho.net;checkip.amazonaws.com;goo.gl;git.io;bit.ly;ow.ly;ip-api.com</QueryName> <!--Malware uses to get external IP address-->
+			<!-- Malicious/Suspicious hosting domains-->
+			<QueryName name="Attack=T1311,Technique=Dynamic DNS,Tactic=Adversary Opsec,Level=4,Alert=Common Malware Hosting Domain: Tiny-share.com,Risk=30" condition="contains any">tiny-share.com;paste.ee;pastebin.com</QueryName>
+			<!--Dynamic DNS Lookups-->
+			<QueryName name="Attack=T1311,Technique=Dynamic DNS,Tactic=Adversary Opsec,Level=3,Alert=Dynamic DNS Query" condition="contains any">afraid.org;duckdns.org;changeip.com;ddns.net;hopto.org;zapto.org;servehttp.com;sytes.net;whoer.net;bravica.net;ip.webmasterhome.cn;whatsmyip.us;myip.kz;ip-addr.es;curlmyip;anysrc.net;anysrc.net;dlinkddns.com;no-ip.com;no-ip.org;no-ip.biz;no-ip.info;noip.com</QueryName>
+			<QueryName name="Attack=T1188,Technique=Multi-hop Proxy,Tactic=Command And Control,Level=4,Alert=Tor2Web,Risk=100" condition="contains any">darknet.to;hiddenservice.net;onion.cab;onion.city;onion.direct;onion.nu;onion.pet;onion.plus;onion.rip;onion.sh;onion.si;onion.to;onion.top;onion.ws;tor-gateways.de;tor2net.com;tor2web.blutmagie.de;tor2web.fi;tor2web.info;tor2web.io;tor2web.org</QueryName>
+			<QueryName name="Attack=T1048,Technique=Exfiltration Over Alternative Protocol,Tactic=Exfiltration,Level=0,Desc=DNS Over HTTPS Detected" condition="contains any">adblock.mydns.network;ibksturm.synology.me;jcdns.fun;ibuki.cgnat.net;dns.twnic.tw;commons.host;doh.dnswarden.com;dns-nyc.aaflalo.me;dns.aaflalo.me;doh.appliedprivacy.net;doh.captnemo.in;doh.tiar.app;doh.tiarap.org;doh.defaultroutes.de;doh.dns.sb;dns.oszx.co;2.dnscrypt-cert.oszx.co;dnscrypt;edns.233py.com;hk-dns.233py.com;hk2dns.233py.com;hkdns.233py.com;hkdns.233py.com;ndns.233py.com;sdns.233py.com;wdns.233py.com;pastebin.com;dns.adguard.com;dns-family.adguard.com;security-filter-dns.cleanbrowsing.org;family-filter-dns.cleanbrowsing.org;adult-filter-dns.cleanbrowsing.org;cloudflare-dns.com;mozilla.cloudflare-dns.com;dns.233py.com;dns.aaflalo.me;dns.google;doh.opendns.com;dns.quad9.net;dns9.quad9.net;dns10.quad9.net;dns11.quad9.net;doh.xfinity.com;dns.nextdns.io;dns.dnsoverhttps.net;doh.crypto.sx;doh.powerdns.org;doh-ch.blahdns.com;doh-de.blahdns.com;dns.rubyfish.cn;dns.containerpi.com;doh-2.seby.io;doh.seby.io;rdns.faelix.net;doh.li;doh.armadillodns.net;doh.netweaver.uk;doh.42l.fr;dns.aa.net.uk</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">gc._msdcs.</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">_kerberos._tcp.dc._msdcs.</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">_kerberos._udp.dc._msdcs.</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">_ldap._tcp.pdc._msdcs.</QueryName>
+			<QueryName name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">wpad</QueryName>
+			<Rule name="Level=3,Desc=Suspicious LDAP Lookup - Useful for identifying tools like sharphound,Risk=90" groupRelation="and">
+				<QueryName condition="begin with">_ldap.</QueryName>
+				<Image condition="excludes">C:\Windows\</Image>
+				<Image condition="excludes">unknown process</Image>
+				<Image condition="excludes all">C:\ProgramData\Microsoft\Windows Defender\Platform\;\MsMpEng.exe</Image>
+			</Rule>
+			<!--
+			<QueryResults name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">type:  28</QueryResults>
+			<QueryResults name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">type:  5</QueryResults>
+			<QueryResults name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">type:  15</QueryResults>
+			<QueryResults name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">type:  2</QueryResults>
+			<QueryResults name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">type:  12</QueryResults>
+			<QueryResults name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">type:  6</QueryResults>
+			<QueryResults name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">type:  99</QueryResults>
+			<QueryResults name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="begin with">type:  33</QueryResults>
+			-->
+			<Image name="Information=Uncategorized Events" condition="contains any">System;svchost.exe;services.exe;unknown process;\;;</Image>
+		</DnsQuery>
+	</RuleGroup>
+	<RuleGroup name="RG=DNS Query Excludes" groupRelation="or">
+		<DnsQuery onmatch="exclude">
+			<!-- Image Exclusions -->
+			<Image condition="begin with">C:\Program Files (x86)\Admin Arsenal\</Image>
+			<Image condition="begin with">C:\Program Files (x86)\CheckPoint\</Image>
+			<Image condition="begin with">C:\Program Files (x86)\Fortinet\</Image>
+			<Image condition="begin with">C:\Program Files (x86)\OpenDNS\OpenDNS Connector</Image>
+			<Image condition="begin with">C:\Program Files (x86)\Razer\Razer Services\</Image>
+			<Image condition="begin with">C:\Program Files (x86)\Trend Micro\</Image>
+			<Image condition="begin with">C:\Program Files (x86)\VMware</Image>
+			<Image condition="begin with">C:\Program Files (x86)\Veeam\</Image>
+			<Image condition="begin with">C:\Program Files\CheckPoint\</Image>
+			<Image condition="begin with">C:\Program Files\Trend Micro\</Image>
+			<Image condition="end with">Slack.exe</Image>
+			<Image condition="end with">\controls\cef\ConnectWise.exe</Image>
+			<Image condition="end with">git-remote-https.exe</Image>
+			<Image condition="image">C:\Program Files (x86)\Enpass\Enpass.exe</Image>
+			<Image condition="image">C:\Program Files (x86)\Fiserv\Vision\VisionGUI.NET.exe</Image>
+			<Image condition="image">C:\Program Files (x86)\Fortinet\FortiClient\update_task.exe</Image>
+			<Image condition="image">C:\Program Files (x86)\Lenovo\System Update\Tvsukernel.exe</Image>
+			<Image condition="image">C:\Program Files\VMware\vCenter Server\jre\bin\java.exe</Image>
+			<Image condition="image">C:\Program Files\VMware\vCenter Server\python\python.exe</Image>
+			<Image condition="image">C:\Windows\SysWOW64\SearchProtocolHost.exe</Image>
+			<Image condition="image">C:\Windows\System32\dsregcmd.exe</Image>
+			<Image condition="image">C:\Windows\sysmon64.exe</Image>
+			<Image condition="image">C:\Windows\sysmon.exe</Image>
+			<QueryName condition="begin with">brave-sync.s3.dualstack.</QueryName>
+			<QueryName condition="end with">.salesforceliveagent.com</QueryName>
+			<QueryName condition="is">ads-serve.brave.com</QueryName>
+			<!--Network noise-->
+			<QueryName condition="end with">.msftncsi.com</QueryName> <!--Microsoft proxy detection | Microsoft default exclusion-->
+			<QueryName condition="is">..localmachine</QueryName>
+			<!--Microsoft-->
+			<QueryName condition="end with">-pushp.svc.ms</QueryName> <!--Microsoft: Doesn't appear to host customer content or subdomains-->
+			<QueryName condition="end with">.b-msedge.net</QueryName> <!--Microsoft: Doesn't appear to host customer content or subdomains-->
+			<QueryName condition="end with">.bing.com</QueryName> <!-- Microsoft | Microsoft default exclusion -->
+			<QueryName condition="end with">.hotmail.com</QueryName> <!--Microsoft | Microsoft default exclusion-->
+			<QueryName condition="end with">.live.com</QueryName> <!--Microsoft | Microsoft default exclusion-->
+			<QueryName condition="end with">.live.net</QueryName> <!--Microsoft | Microsoft default exclusion-->
+			<QueryName condition="end with">.microsoft.com</QueryName> <!--Microsoft | Microsoft default exclusion-->
+			<QueryName condition="end with">.microsoftonline.com</QueryName> <!--Microsoft | Microsoft default exclusion-->
+			<QueryName condition="end with">.microsoftstore.com</QueryName> <!--Microsoft | Microsoft default exclusion-->
+			<QueryName condition="end with">.ms-acdc.office.com</QueryName> <!--Microsoft: Doesn't appear to host customer content or subdomains-->
+			<QueryName condition="end with">.msedge.net</QueryName> <!--Microsoft: Doesn't appear to host customer content or subdomains-->
+			<QueryName condition="end with">.msn.com</QueryName> <!--Microsoft | Microsoft default exclusion-->
+			<QueryName condition="end with">.msocdn.com</QueryName> <!--Microsoft-->
+			<QueryName condition="end with">.s-microsoft.com</QueryName> <!--Microsoft-->
+			<QueryName condition="end with">.skype.com</QueryName> <!--Microsoft | Microsoft default exclusion-->
+			<QueryName condition="end with">.skype.net</QueryName> <!--Microsoft | Microsoft default exclusion-->
+			<QueryName condition="end with">.windows.com</QueryName> <!--Microsoft-->
+			<QueryName condition="end with">.windows.net.nsatc.net</QueryName> <!--Microsoft-->
+			<QueryName condition="end with">.windowsupdate.com</QueryName> <!--Microsoft-->
+			<QueryName condition="end with">.xboxlive.com</QueryName> <!--Microsoft-->
+			<QueryName condition="is">login.windows.net</QueryName> <!--Microsoft-->
+			<!--Microsoft:Office365/AzureAD-->
+			<QueryName condition="end with">.activedirectory.windowsazure.com</QueryName> <!--Microsoft: AzureAD-->
+			<QueryName condition="end with">.msauth.net</QueryName>
+			<QueryName condition="end with">.msftauth.net</QueryName>
+			<QueryName condition="end with">.opinsights.azure.com</QueryName> <!--Microsoft: AzureAD/InTune client event monitoring-->
+			<QueryName condition="is">management.azure.com</QueryName> <!--Microsoft: AzureAD/InTune-->
+			<QueryName condition="is">outlook.office365.com</QueryName> <!--Microsoft: Protected by HSTS-->
+			<QueryName condition="is">portal.azure.com</QueryName> <!--Microsoft: AzureAD/InTune-->
+			<!--3rd-party applications-->
+			<QueryName condition="end with">.mozaws.net</QueryName> <!--Mozilla-->
+			<QueryName condition="end with">.mozilla.com</QueryName> <!--Mozilla-->
+			<QueryName condition="end with">.mozilla.net</QueryName> <!--Mozilla-->
+			<QueryName condition="end with">.mozilla.org</QueryName> <!--Mozilla-->
+			<QueryName condition="end with">.spotify.com</QueryName> <!--Spotify-->
+			<QueryName condition="end with">.spotify.map.fastly.net</QueryName> <!--Spotify-->
+			<QueryName condition="end with">googleapis.com</QueryName> <!--Google-->
+			<QueryName condition="is">clients1.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">clients2.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">clients3.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">clients4.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">clients5.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">clients6.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">cloudsearch.googleapis.com</QueryName> <!--Google-->
+			<QueryName condition="is">id.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">safebrowsing.googleapis.com</QueryName> <!--Google-->
+			<QueryName condition="is">www.googleapis.com</QueryName> <!--Google-->
+			<!--Goodlist CDN-->
+			<QueryName condition="end with">.akadns.net</QueryName> <!--AkamaiCDN, extensively used by Microsoft | Microsoft default exclusion-->
+			<QueryName condition="end with">.netflix.com</QueryName>
+			<QueryName condition="end with">.typekit.net</QueryName> <!--Adobe fonts-->
+			<QueryName condition="end with">aspnetcdn.com</QueryName> <!--Microsoft [ https://docs.microsoft.com/en-us/aspnet/ajax/cdn/overview ]-->
+			<QueryName condition="is">ajax.googleapis.com</QueryName>
+			<QueryName condition="is">cdnjs.cloudflare.com</QueryName>
+			<QueryName condition="is">cdnjs.cloudflare.com</QueryName> <!--Cloudflare: Hosts popular javascript libraries-->
+			<QueryName condition="is">fonts.googleapis.com</QueryName> <!--Google fonts-->
+			<!--Personal-->
+			<QueryName condition="end with">.steamcontent.com</QueryName> <!--If you seriously host malware C2 in game binaries in Steam, I give up-->
+			<!--Web resources-->
+			<QueryName condition="end with">.disqus.com</QueryName> <!--Microsoft default exclusion-->
+			<QueryName condition="end with">.fontawesome.com</QueryName>
+			<QueryName condition="is">disqus.com</QueryName> <!--Microsoft default exclusion-->
+			<!--Ads-->
+			<QueryName condition="end with">.1rx.io</QueryName> <!--Ads-->
+			<QueryName condition="end with">.2mdn.net</QueryName> <!--Ads: Google | Microsoft default exclusion-->
+			<QueryName condition="end with">.adadvisor.net</QueryName> <!--Ads: Neustar [ https://better.fyi/trackers/adadvisor.net/ ] -->
+			<QueryName condition="end with">.adap.tv</QueryName> <!--Ads:AOL | Microsoft default exclusion [ https://www.crunchbase.com/organization/adap-tv ] -->
+			<QueryName condition="end with">.addthis.com</QueryName> <!--Ads:Oracle | Microsoft default exclusion [ https://en.wikipedia.org/wiki/AddThis ] -->
+			<QueryName condition="end with">.adform.net</QueryName> <!--Ads-->
+			<QueryName condition="end with">.adnxs.com</QueryName> <!--Ads: AppNexus | Microsoft default exclusion-->
+			<QueryName condition="end with">.adroll.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.adrta.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.adsafeprotected.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.adsrvr.org</QueryName> <!--Ads-->
+			<QueryName condition="end with">.advertising.com</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.amazon-adsystem.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.amazon-adsystem.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.analytics.yahoo.com</QueryName> <!--Ads:Yahoo-->
+			<QueryName condition="end with">.aol.com</QueryName> <!--Ads | Microsoft default exclusion -->
+			<QueryName condition="end with">.betrad.com</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.bidswitch.net</QueryName> <!--Ads-->
+			<QueryName condition="end with">.casalemedia.com</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.chartbeat.net</QueryName> <!--Ads | Microsoft default exclusion [ https://better.fyi/trackers/chartbeat.com/ ]-->
+			<QueryName condition="end with">.cnn.com</QueryName> <!-- Microsoft default exclusion-->
+			<QueryName condition="end with">.convertro.com</QueryName> <!--Ads:Verizon-->
+			<QueryName condition="end with">.criteo.com</QueryName> <!--Ads [ https://better.fyi/trackers/criteo.com/ ] -->
+			<QueryName condition="end with">.criteo.net</QueryName> <!--Ads [ https://better.fyi/trackers/criteo.com/ ] -->
+			<QueryName condition="end with">.crwdcntrl.net</QueryName> <!--Ads: Lotame [ https://better.fyi/trackers/crwdcntrl.net/ ] -->
+			<QueryName condition="end with">.demdex.net</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.domdex.com</QueryName> 
+			<QueryName condition="end with">.dotomi.com</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.doubleclick.net</QueryName> <!--Ads:Conversant | Microsoft default exclusion [ https://www.crunchbase.com/organization/dotomi ] -->
+			<QueryName condition="end with">.doubleverify.com</QueryName> <!--Ads: Google-->
+			<QueryName condition="end with">.emxdgt.com</QueryName> <!--Ads: EMX-->
+			<QueryName condition="end with">.exelator.com</QueryName> <!--Ads:Nielson Marketing Cloud-->
+			<QueryName condition="end with">.google-analytics.com</QueryName> <!--Ads:Google | Microsoft default exclusion-->
+			<QueryName condition="end with">.googleadservices.com</QueryName> <!--Google-->
+			<QueryName condition="end with">.googlesyndication.com</QueryName> <!--Ads:Google, sometimes called during malicious ads, but not directly responsible | Microsoft default exclusion [ https://www.hackread.com/wp-content/uploads/2018/06/Bitdefender-Whitepaper-Zacinlo.pdf ]-->
+			<QueryName condition="end with">.googletagmanager.com</QueryName> <!--Google-->
+			<QueryName condition="end with">.googlevideo.com</QueryName> <!--Google | Microsoft default exclusion-->
+			<QueryName condition="end with">.gstatic.com</QueryName> <!--Google | Microsoft default exclusion-->
+			<QueryName condition="end with">.gvt1.com</QueryName> <!--Google-->
+			<QueryName condition="end with">.gvt2.com</QueryName> <!--Google-->
+			<QueryName condition="end with">.ib-ibi.com</QueryName> <!--Ads: Offerpath [ https://better.fyi/trackers/ib-ibi.com/ ] -->
+			<QueryName condition="end with">.jivox.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.mathtag.com</QueryName> <!--Microsoft default exclusion-->
+			<QueryName condition="end with">.moatads.com</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.moatpixel.com</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.mookie1.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.myvisualiq.net</QueryName> <!--Ads-->
+			<QueryName condition="end with">.netmng.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.nexac.com</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.nexac.com</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.openx.net</QueryName> <!--Ads-->
+			<QueryName condition="end with">.optimizely.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.outbrain.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.pardot.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.phx.gbl</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.pinterest.com</QueryName> <!--Pinerest-->
+			<QueryName condition="end with">.pubmatic.com</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.quantcount.com</QueryName>
+			<QueryName condition="end with">.quantserve.com</QueryName>
+			<QueryName condition="end with">.revsci.net</QueryName> <!--Ads:Omniture | Microsoft default exclusion-->
+			<QueryName condition="end with">.rfihub.net</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.rlcdn.com</QueryName> <!--Ads: Rapleaf [ https://better.fyi/trackers/rlcdn.com/ ] -->
+			<QueryName condition="end with">.rubiconproject.com</QueryName> <!--Ads: Rubicon Project | Microsoft default exclusion [ https://better.fyi/trackers/rubiconproject.com/ ] -->
+			<QueryName condition="end with">.scdn.co</QueryName> <!--Spotify-->
+			<QueryName condition="end with">.scorecardresearch.com</QueryName> <!--Ads: Comscore | Microsoft default exclusion-->
+			<QueryName condition="end with">.serving-sys.com</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.sharethrough.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.simpli.fi</QueryName>
+			<QueryName condition="end with">.sitescout.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.smartadserver.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.snapads.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.spotxchange.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.taboola.com</QueryName> <!--Ads:Taboola-->
+			<QueryName condition="end with">.taboola.map.fastly.net</QueryName> <!--Ads:Taboola-->
+			<QueryName condition="end with">.tapad.com</QueryName>
+			<QueryName condition="end with">.tidaltv.com</QueryName> <!--Ads: Videology [ https://better.fyi/trackers/tidaltv.com/ ] -->
+			<QueryName condition="end with">.trafficmanager.net</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.tremorhub.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.tribalfusion.com</QueryName> <!--Ads: Exponential [ https://better.fyi/trackers/tribalfusion.com/ ] -->
+			<QueryName condition="end with">.turn.com</QueryName> <!--Ads | Microsoft default exclusion [ https://better.fyi/trackers/turn.com/ ] -->
+			<QueryName condition="end with">.twimg.com</QueryName> <!--Ads | Microsoft default exclusion-->
+			<QueryName condition="end with">.tynt.com</QueryName> <!--Ads-->
+			<QueryName condition="end with">.w55c.net</QueryName> <!--Ads:dataxu-->
+			<QueryName condition="end with">.ytimg.com</QueryName> <!--Google-->
+			<QueryName condition="end with">.zorosrv.com</QueryName> <!--Ads:Taboola-->
+			<QueryName condition="end with">ads.yahoo.com</QueryName> <!--Ads: Yahoo-->
+			<QueryName condition="is">1rx.io</QueryName>
+			<QueryName condition="is">adservice.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">ampcid.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">clientservices.googleapis.com</QueryName> <!--Google-->
+			<QueryName condition="is">d29x207vrinatv.cloudfront.net</QueryName> <!--Amazon-developed applications-->
+			<QueryName condition="is">googleadapis.l.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">imasdk.googleapis.com</QueryName> <!--Google [ https://developers.google.com/interactive-media-ads/docs/sdks/html5/ ] -->
+			<QueryName condition="is">l.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">ml314.com</QueryName> <!--Ads-->
+			<QueryName condition="is">mtalk.google.com</QueryName> <!--Google-->
+			<QueryName condition="is">update.googleapis.com</QueryName> <!--Google-->
+			<QueryName condition="is">www.googletagservices.com</QueryName>
+			<!--SocialNet-->
+			<QueryName condition="end with">.pscp.tv</QueryName> <!--Twitter:Periscope-->
+			<!--OSCP/CRL Common-->
+			<QueryName condition="contains">adsniper.ru</QueryName>
+			<QueryName condition="contains">cdnvideo.ru</QueryName>
+			<QueryName condition="contains">chat.minergate.com</QueryName>
+			<QueryName condition="contains">cwsa.minergate.com</QueryName>
+			<QueryName condition="contains">forum.minergate.com</QueryName>
+			<QueryName condition="contains">leadlab.click</QueryName>
+			<QueryName condition="contains">mc.yandex.ru</QueryName>
+			<QueryName condition="contains">pool.ntp.org</QueryName>
+			<QueryName condition="contains">vmg.host</QueryName>
+			<QueryName condition="contains">yandex.ru</QueryName>
+			<QueryName condition="end with">.adobe.com</QueryName>
+			<QueryName condition="end with">.autodesk.com</QueryName>
+			<QueryName condition="end with">.avast.com</QueryName>
+			<QueryName condition="end with">.avcdn.net</QueryName>
+			<QueryName condition="end with">.cdn.bitdefender.net</QueryName>
+			<QueryName condition="end with">.digicert.com</QueryName>
+			<QueryName condition="end with">.eset.com</QueryName>
+			<QueryName condition="end with">.globalsign.com</QueryName>
+			<QueryName condition="end with">.globalsign.net</QueryName>
+			<QueryName condition="end with">.intuit.com</QueryName>
+			<QueryName condition="end with">.java.com</QueryName>
+			<QueryName condition="end with">.macromedia.com</QueryName>
+			<QueryName condition="end with">.oracle.com</QueryName>
+			<QueryName condition="end with">.quickbooks.com</QueryName>
+			<QueryName condition="end with">.usertrust.com</QueryName>
+			<QueryName condition="end with">amazontrust.com</QueryName>
+			<QueryName condition="end with">ocsp.identrust.com</QueryName>
+			<QueryName condition="end with">pki.goog</QueryName>
+			<QueryName condition="is">ads.playground.xyz</QueryName>
+			<QueryName condition="is">citrixupdates.cloud.com</QueryName>
+			<QueryName condition="is">forticlient.fortinet.net</QueryName>
+			<QueryName condition="is">mft10.onbaseonline.com</QueryName>
+			<QueryName condition="is">msocsp.com</QueryName> <!--Microsoft:OCSP-->
+			<QueryName condition="is">ocsp.comodoca.com</QueryName>
+			<QueryName condition="is">ocsp.cybertrust.ne.jp</QueryName>
+			<QueryName condition="is">ocsp.entrust.net</QueryName>
+			<QueryName condition="is">ocsp.entrust.net</QueryName>
+			<QueryName condition="is">ocsp.godaddy.com</QueryName>
+			<QueryName condition="is">ocsp.int-x3.letsencrypt.org</QueryName>
+			<QueryName condition="is">ocsp.intel.com</QueryName>
+			<QueryName condition="is">ocsp.msocsp.com</QueryName> <!--Microsoft:OCSP-->
+			<QueryName condition="is">ocsp.quovadisglobal.com</QueryName>
+			<QueryName condition="is">ocsp.quovadisoffshore.com</QueryName>
+			<QueryName condition="is">ocsp.sectigo.com</QueryName>
+			<QueryName condition="is">ocsp.starfieldtech.com</QueryName>
+			<QueryName condition="is">ocsp.thawte.com</QueryName>
+			<QueryName condition="is">ocsp.trustwave.com</QueryName>
+			<QueryName condition="is">ocsp.verisign.com</QueryName>
+			<QueryName condition="is">pki-goog.l.google.com</QueryName>
+			<QueryName condition="is">pki.intel.com</QueryName>
+			<QueryName condition="is">scrootca1.ocsp.secomtrust.net</QueryName>
+			<QueryName condition="is">scrootca2.ocsp.secomtrust.net</QueryName>
+			<QueryName condition="is">stats.anchor.host</QueryName>
+			<QueryName condition="is">status.rapidssl.com</QueryName>
+			<QueryName condition="is">status.thawte.com</QueryName>
+			<QueryName condition="is">ts-ocsp.ws.symantec.com</QueryName>
+			<QueryName condition="is">upgrade.bitdefender.com</QueryName>
+		</DnsQuery>
+	</RuleGroup>
+	<!-- SYSMON EVENT ID 23 : File Delete and overwrite events which saves a copy to the archivedir: Includes -->
+	<!-- Default set to disabled due to disk space implications, enable with care!-->
+	<RuleGroup groupRelation="or">
+	  <FileDelete onmatch="include" />
+	</RuleGroup>
+	<!-- SYSMON EVENT ID 24 : Clipboard change events, only captures text, not files: Includes -->
+	<!-- Default set to disabled due to privacy implications and potential data you leave for attackers, enable with care!-->
+	<RuleGroup groupRelation="or">
+	  <ClipboardChange onmatch="include" />
+	</RuleGroup>
+	<!--SYSMON EVENT ID 25 : Process tampering events-->
+	<RuleGroup name="RG=Process Tampering Includes" groupRelation="or">
+		<ProcessTampering onmatch="include">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">.;&gt;;unknown;anonymous</Image>
+				<Image condition="excludes">C:\Program Files (x86)\Google\Chrome\Application\chrome.exe</Image>
+				<Image condition="excludes">C:\Program Files (x86)\Symantec\</Image>
+				<Image condition="excludes">C:\Program Files\Google\Chrome\Application\chrome.exe</Image>
+				<Image condition="excludes">C:\Program Files\Symantec\</Image>
+			</Rule>
+		</ProcessTampering>
+	</RuleGroup>
+	<RuleGroup name="RG=Process Tampering Excludes" groupRelation="or">
+		<ProcessTampering onmatch="exclude">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">\BHO\ie_to_edge_stub.exe;\Microsoft\Teams\;\Vivaldi\Application\;Google\Chrome\;Google\Update;BraveSoftware\Brave-Browser\;Edge\Application\;EdgeUpdate\Install\;Program Files\SmartGit\</Image>
+			</Rule>
+		</ProcessTampering>
+	</RuleGroup>
+	<!-- SYSMON EVENT ID 26 : File Delete and overwrite events, does NOT save the file: Includes -->
+	<RuleGroup groupRelation="or">
+		<FileDeleteDetected onmatch="include">
+		</FileDeleteDetected>
+	</RuleGroup>
+	<RuleGroup groupRelation="or">
+		<FileDeleteDetected onmatch="exclude">
+			<Image condition="contains all">\appdata\local\google\chrome\user data\swreporter\;software_reporter_tool.exe</Image>
+			<Image condition="is">C:\Program Files (x86)\Google\Chrome\Application\chrome.exe</Image>
+			<User condition="contains any">NETWORK SERVICE; LOCAL SERVICE</User>
+		</FileDeleteDetected>
+	</RuleGroup>
+	<!--SYSMON EVENT ID 27 : FILE BLOCK [FileBlockExecutable]-->
+	<RuleGroup name="RG=ImageBlock Include Group" groupRelation="or">
+		<FileBlockExecutable onmatch="include">
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">OUTLOOK.exe;WINWORD.exe;EXCEL.EXE;powerpnt.exe;msaccess.exe;mspub.exe;eqnedt32.exe;visio.exe;wordpad.exe;wordview.exe;msohtmed.exe;lync.exe;teams.exe</Image>
+				<TargetFilename condition="excludes any">:\Program Files\Microsoft Office\;:\Program Files (x86)\Microsoft Office\</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">w3wp.exe;tomcat;apache;nginx;httpd</Image>
+				<TargetFilename condition="excludes any">whitelist_me_here</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">powershell.exel;powershell_ise.exe</Image>
+				<TargetFilename condition="excludes any">whitelist_me_here</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="end with">.exe</TargetFilename>
+				<TargetFilename condition="contains any">.pdf;.doc;.xls;.doc;.ppt;.txt;.rtf;.htm;.iso;.zip;.rar;.7z</TargetFilename>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="or">
+				<Image condition="contains any">psexesvc</Image>
+				<Image condition="contains any">psexec</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="or">
+				<Image condition="is">wmiprvse.exe</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<TargetFilename condition="begin with">C:\Users\Public\</TargetFilename>
+				<TargetFilename condition="excludes any">amdsfhdcd.bin</TargetFilename>
+				<Image condition="excludes any">intuit</Image>
+			</Rule>
+			<Rule name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" groupRelation="and">
+				<Image condition="contains any">AcroRd32.exe;notepad.exe;mshta.exe;hh.exe;certutil.exe;certoc.exe;certreq.exe;desktopimgdownldr.exe;esentutl.exe;finger.exe;presentationhost.exe;cscript.exe;wscript.exe;mspaint.exe;RdrCEF.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1311,Technique=User Execution: Malicious File,Tactic=Execution,Level=4,Alert=Malicious File Detection,Author=Florian Roth" groupRelation="or">
+				<Hashes condition="contains">IMPHASH=BCCA3C247B619DCD13C8CDFF5F123932</Hashes> <!-- PetitPotam -->
+				<Hashes condition="contains">IMPHASH=3A19059BD7688CB88E70005F18EFC439</Hashes> <!-- PetitPotam -->
+				<Hashes condition="contains">IMPHASH=bf6223a49e45d99094406777eb6004ba</Hashes> <!-- PetitPotam -->
+				<Hashes condition="contains">IMPHASH=0C106686A31BFE2BA931AE1CF6E9DBC6</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=0D1447D4B3259B3C2A1D4CFB7ECE13C3</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=1B0369A1E06271833F78FFA70FFB4EAF</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=4C1B52A19748428E51B14C278D0F58E3</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=4D927A711F77D62CEBD4F322CB57EC6F</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=66EE036DF5FC1004D9ED5E9A94A1086A</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=672B13F4A0B6F27D29065123FE882DFC</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=6BBD59CEA665C4AFCC2814C1327EC91F</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=725BB81DC24214F6ECACC0CFB36AD30D</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=9528A0E91E28FBB88AD433FEABCA2456</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=9DA6D5D77BE11712527DCAB86DF449A3</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=A6E01BC1AB89F8D91D9EAB72032AAE88</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=B24C5EDDAEA4FE50C6A96A2A133521E4</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=D21BBC50DCC169D7B4D0F01962793154</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=FCC251CCEAE90D22C392215CC9A2D5D6</Hashes> <!-- Mimikatz -->
+				<Hashes condition="contains">IMPHASH=23867A89C2B8FC733BE6CF5EF902F2D1</Hashes> <!-- JuicyPotato  -->
+				<Hashes condition="contains">IMPHASH=A37FF327F8D48E8A4D2F757E1B6E70BC</Hashes> <!-- JuicyPotato  -->
+				<Hashes condition="contains">IMPHASH=6118619783FC175BC7EBECFF0769B46E</Hashes> <!-- RoguePotato -->
+				<Hashes condition="contains">IMPHASH=959A83047E80AB68B368FDB3F4C6E4EA</Hashes> <!-- RoguePotato -->
+				<Hashes condition="contains">IMPHASH=563233BFA169ACC7892451F71AD5850A</Hashes> <!-- RoguePotato -->
+				<Hashes condition="contains">IMPHASH=87575CB7A0E0700EB37F2E3668671A08</Hashes> <!-- RoguePotato -->
+				<Hashes condition="contains">IMPHASH=13F08707F759AF6003837A150A371BA1</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=1781F06048A7E58B323F0B9259BE798B</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=233F85F2D4BC9D6521A6CAAE11A1E7F5</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=24AF2584CBF4D60BBE5C6D1B31B3BE6D</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=632969DDF6DBF4E0F53424B75E4B91F2</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=713C29B396B907ED71A72482759ED757</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=749A7BB1F0B4C4455949C0B2BF7F9E9F</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=8628B2608957A6B0C6330AC3DE28CE2E</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=8B114550386E31895DFAB371E741123D</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=94CB940A1A6B65BED4D5A8F849CE9793</Hashes> <!-- PwDumpX -->
+				<Hashes condition="contains">IMPHASH=9D68781980370E00E0BD939EE5E6C141</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=B18A1401FF8F444056D29450FBC0A6CE</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=CB567F9498452721D77A451374955F5F</Hashes> <!-- Pwdump -->
+				<Hashes condition="contains">IMPHASH=730073214094CD328547BF1F72289752</Hashes> <!-- Htran -->
+				<Hashes condition="contains">IMPHASH=17B461A082950FC6332228572138B80C</Hashes> <!-- Cobalt Strike beacons -->
+				<Hashes condition="contains">IMPHASH=DC25EE78E2EF4D36FAA0BADF1E7461C9</Hashes> <!-- Cobalt Strike beacons -->
+				<Hashes condition="contains">IMPHASH=819B19D53CA6736448F9325A85736792</Hashes> <!-- Cobalt Strike beacons -->
+				<Hashes condition="contains">IMPHASH=829DA329CE140D873B4A8BDE2CBFAA7E</Hashes> <!-- Cobalt Strike beacons -->
+				<Hashes condition="contains">IMPHASH=C547F2E66061A8DFFB6F5A3FF63C0A74</Hashes> <!-- PPLDump -->
+				<Hashes condition="contains">IMPHASH=0588081AB0E63BA785938467E1B10CCA</Hashes> <!-- PPLDump -->
+				<Hashes condition="contains">IMPHASH=0D9EC08BAC6C07D9987DFD0F1506587C</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=BC129092B71C89B4D4C8CDF8EA590B29</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=4DA924CF622D039D58BCE71CDF05D242</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=E7A3A5C377E2D29324093377D7DB1C66</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=9A9DBEC5C62F0380B4FA5FD31DEFFEDF</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=AF8A3976AD71E5D5FDFB67DDB8DADFCE</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=0C477898BBF137BBD6F2A54E3B805FF4</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=0CA9F02B537BCEA20D4EA5EB1A9FE338</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=3AB3655E5A14D4EEFC547F4781BF7F9E</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=E6F9D5152DA699934B30DAAB206471F6</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=3AD59991CCF1D67339B319B15A41B35D</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=FFDD59E0318B85A3E480874D9796D872</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=0CF479628D7CC1EA25EC7998A92F5051</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=07A2D4DCBD6CB2C6A45E6B101F0B6D51</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=D6D0F80386E1380D05CB78E871BC72B1</Hashes> <!-- NanoDump -->
+				<Hashes condition="contains">IMPHASH=38D9E015591BBFD4929E0D0F47FA0055</Hashes> <!-- HandleKatz -->
+				<Hashes condition="contains">IMPHASH=0E2216679CA6E1094D63322E3412D650</Hashes> <!-- HandleKatz -->
+				<Hashes condition="contains">IMPHASH=ADA161BF41B8E5E9132858CB54CAB5FB</Hashes> <!-- DripLoader -->
+				<Hashes condition="contains">IMPHASH=2A1BC4913CD5ECB0434DF07CB675B798</Hashes> <!-- DripLoader -->
+				<Hashes condition="contains">IMPHASH=11083E75553BAAE21DC89CE8F9A195E4</Hashes> <!-- DripLoader -->
+				<Hashes condition="contains">IMPHASH=A23D29C9E566F2FA8FFBB79267F5DF80</Hashes> <!-- DripLoader -->
+				<Hashes condition="contains">IMPHASH=4A07F944A83E8A7C2525EFA35DD30E2F</Hashes> <!-- CreateMiniDump -->
+				<Hashes condition="contains">IMPHASH=767637C23BB42CD5D7397CF58B0BE688</Hashes> <!-- UACMe Akagi -->
+				<Hashes condition="contains">IMPHASH=14C4E4C72BA075E9069EE67F39188AD8</Hashes> <!-- UACMe Akagi -->
+				<Hashes condition="contains">IMPHASH=3C782813D4AFCE07BBFC5A9772ACDBDC</Hashes> <!-- UACMe Akagi -->
+				<Hashes condition="contains">IMPHASH=7D010C6BB6A3726F327F7E239166D127</Hashes> <!-- UACMe Akagi -->
+				<Hashes condition="contains">IMPHASH=89159BA4DD04E4CE5559F132A9964EB3</Hashes> <!-- UACMe Akagi -->
+				<Hashes condition="contains">IMPHASH=6F33F4A5FC42B8CEC7314947BD13F30F</Hashes> <!-- UACMe Akagi -->
+				<Hashes condition="contains">IMPHASH=5834ED4291BDEB928270428EBBAF7604</Hashes> <!-- UACMe Akagi -->
+				<Hashes condition="contains">IMPHASH=5A8A8A43F25485E7EE1B201EDCBC7A38</Hashes> <!-- UACMe Akagi -->
+				<Hashes condition="contains">IMPHASH=DC7D30B90B2D8ABF664FBED2B1B59894</Hashes> <!-- UACMe Akagi -->
+				<Hashes condition="contains">IMPHASH=41923EA1F824FE63EA5BEB84DB7A3E74</Hashes> <!-- UACMe Akagi -->
+				<Hashes condition="contains">IMPHASH=3DE09703C8E79ED2CA3F01074719906B</Hashes> <!-- UACMe Akagi -->
+				<Hashes condition="contains">IMPHASH=A53A02B997935FD8EEDCB5F7ABAB9B9F</Hashes> <!-- WCE -->
+				<Hashes condition="contains">IMPHASH=E96A73C7BF33A464C510EDE582318BF2</Hashes> <!-- WCE -->
+				<Hashes condition="contains">IMPHASH=32089B8851BBF8BC2D014E9F37288C83</Hashes> <!-- Sliver Stagers -->
+				<Hashes condition="contains">IMPHASH=09D278F9DE118EF09163C6140255C690</Hashes> <!-- Dumpert -->
+				<Hashes condition="contains">IMPHASH=03866661686829D806989E2FC5A72606</Hashes> <!-- Dumpert -->
+				<Hashes condition="contains">IMPHASH=E57401FBDADCD4571FF385AB82BD5D6D</Hashes> <!-- Dumpert -->
+				<Hashes condition="contains">IMPHASH=84B763C45C0E4A3E7CA5548C710DB4EE</Hashes> <!-- SysmonEnte -->
+				<Hashes condition="contains">IMPHASH=19584675D94829987952432E018D5056</Hashes> <!-- SysmonQuiet -->
+				<Hashes condition="contains">IMPHASH=330768A4F172E10ACB6287B87289D83B</Hashes> <!-- ShaprEvtMute Hook -->
+			</Rule>
+			<Rule name="Attack=T1562.002,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=Tools that tamper with Sysmon,Author=Florian Roth" groupRelation="and">
+				<TargetFilename condition="contains any">\EntenLoader.exe;\SysmonQuiet.exe;\SharpEvtMute.exe;\EvtMuteHook.dll</TargetFilename>
+			</Rule>
+			<Rule name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=4,Desc=Lolbins dropping binaries,Author=Florian Roth" groupRelation="or">
+				<Image condition="image">certutil.exe</Image>
+				<Image condition="image">certoc.exe</Image>
+				<Image condition="image">CertReq.exe</Image>
+				<!-- <Image condition="image">bitsadmin.exe</Image> (depends on the environment; comment in if you're sure that bitsadmin doesn't do that in your env) -->
+				<Image condition="image">Desktopimgdownldr.exe</Image>
+				<Image condition="image">esentutl.exe</Image>
+				<!-- <Image condition="image">expand.exe</Image> (depends on the environment; comment in if you're sure that expand doesn't do that in your env) -->
+				<Image condition="image">finger.exe</Image>
+				<Image condition="image">presentationhost.exe</Image>
+			</Rule>
+			<Rule name="Attack=T1105,Technique=Ingress Tool Transfer,Tactic=Command and Control,Level=4,Desc=Suspicious Bitsadmin Usage from Non System accounts,Author=@ionstorm" groupRelation="and">
+				<Image condition="image">bitsadmin.exe</Image>
+				<TargetFilename condition="excludes any">C:\Windows;$WINDOWS.;\SoftwareDistribution\</TargetFilename>
+				<User condition="is not">System</User>
+				<User condition="excludes any">TrustedInstaller;NT AUTHORITY\NETWORK SERVICE;NT AUTHORITY\LOCAL SERVICE;SERVICE LOCAL;ERVICE RÉSEAU;NETZWERKDIENST;LOKALER DIENST;NETZWERKDIENST;SERVICIO DE RED;ERVICIO LOC</User>
+			</Rule>
+			<Rule name="Attack=T1562.002,Technique=Impair Defenses: Disable Windows Event Logging,Tactic=Defense Evasion,Level=4,Alert=Tools that tamper with Sysmon,Author=Florian Roth" groupRelation="and">
+				<TargetFilename condition="contains any">\EntenLoader.exe;\SysmonQuiet.exe;\SharpEvtMute.exe;\EvtMuteHook.dll</TargetFilename>
+			</Rule>
+		</FileBlockExecutable>
+	</RuleGroup>
+	</EventFiltering>
+</Sysmon>


### PR DESCRIPTION
All common background forensic events have same name field structure.

**Old style**
```
<Image name="Level=0,Desc=WSL Execution" condition="contains">\LocalState\rootfs\</Image>
```

**New below** 

```<Image name="Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event" condition="contains">\LocalState\rootfs\</Image>```

This means we can use XPATH filter similiar to below

```
<QueryList>
  <Query Id="0" Path="Microsoft-Windows-Sysmon/Operational">
    <Select Path="Microsoft-Windows-Sysmon/Operational">
      *[System[EventID ='1']] and
      *[EventData[Data[@Name='RuleName'] != '-']] 
    </Select>
    <Suppress Path="Microsoft-Windows-Sysmon/Operational">
      *[EventData[Data[@Name='RuleName'] = 'Attack=None,Technique=None,Tactic=None,Level=0,Desc=Potential Background Event']] 
    </Suppress>
  </Query>
</QueryList>
```

This will reduce log volume into a SIEM v solution whilst retaining evidence in Microsoft-Windows-Sysmon/Operational log file.